### PR TITLE
Lvm setup and wait for socket

### DIFF
--- a/packer/app.json
+++ b/packer/app.json
@@ -34,7 +34,7 @@
     {
       "type":           "shell",
       "inline": [
-        "sudo apt-get install -y git"
+        "sudo apt-get install -y git lvm2"
       ]
     },
     {

--- a/packer/app/docker-worker-static.conf
+++ b/packer/app/docker-worker-static.conf
@@ -6,6 +6,9 @@ stop on shutdown
 respawn
 
 script
+  # Wait until docker socket is available
+  while [ ! -e "/var/run/docker.sock" ];
+  do echo "Waiting for /var/run/docker.sock"; sleep 3; done;
   DOCKER_WORKER='/home/ubuntu/docker_worker/bin/worker start'
   DOCKER_WORKER_OPTS=
   if [ -f /etc/default/$UPSTART_JOB ]; then

--- a/packer/app/docker-worker-updating.conf
+++ b/packer/app/docker-worker-updating.conf
@@ -6,6 +6,9 @@ stop on shutdown
 respawn
 
 script
+  # Wait until docker socket is available
+  while [ ! -e "/var/run/docker.sock" ];
+  do echo "Waiting for /var/run/docker.sock"; sleep 3; done;
   bash --login -c "rm -rf /home/ubuntu/docker-worker/";
   bash --login -c "git clone https://github.com/taskcluster/docker-worker.git /home/ubuntu/docker-worker";
   DOCKER_WORKER='/home/ubuntu/docker-worker/docker_worker/bin/worker start'

--- a/packer/app/etc/default/docker
+++ b/packer/app/etc/default/docker
@@ -1,5 +1,24 @@
 # /etc/default/docker
- 
+
+# Find instance storage devices
+DEVICES=`ls /dev/xvd* | grep -v '/dev/xvda1'`;
+
+# Unmount block-device if already mounted, the first block-device always is
+for d in $DEVICES; do umount $d || true; done
+
+# Create volume group containing all instance storage devices
+echo $DEVICES | xargs vgcreate instance_storage
+
+# Create logical volume with all storage
+lvcreate -l 100%VG -n all instance_storage
+
+# Format logical volume with ext4
+mkfs.ext4 /dev/instance_storage/all
+
+# Mount on /mnt
+mount /dev/instance_storage/all /mnt
+
+
 mkdir -p /mnt/var/lib/docker
 mkdir -p /mnt/docker-tmp
 export TMPDIR="/mnt/docker-tmp"

--- a/packer/base.json
+++ b/packer/base.json
@@ -5,7 +5,8 @@
       "type": "shell",
       "scripts": [
         "packer/base/scripts/docker.sh",
-        "packer/base/scripts/node.sh"
+        "packer/base/scripts/node.sh",
+        "packer/base/scripts/lvm.sh",
       ]
     }
   ],

--- a/packer/base/scripts/lvm.sh
+++ b/packer/base/scripts/lvm.sh
@@ -1,0 +1,11 @@
+#! /bin/bash -vxe
+
+# Update your sources
+sudo apt-get update
+sudo apt-get upgrade -y
+
+# Install LVM2
+sudo apt-get install -y lvm2
+
+# Actual lvm configuration can first be done at launch time, as we don't know
+# how many instance storage devices we have available.


### PR DESCRIPTION
This is based on the PR #24, please merge it first. There is only commit specific to this PR.

First this fixes [bug 985832](https://bugzilla.mozilla.org/show_bug.cgi?id=985832) mounting all available instance storage on `/mnt/` using LVM.

And as bonous I fixed [bug 990287](https://bugzilla.mozilla.org/show_bug.cgi?id=990287) which would likely have caused more issues as formatting the disk makes docker startup take a little extra time, or 10s-30s or so - don't have exact measurements.

**Note**, I didn't run a test to see if `/var/run/docker.sock` was indeed missing. But log output shows that `docker-worker.log` prints out `"Waiting for /var/run/docker.sock"`, and have I haven't been getting issues with first task failing since I introduced this. So a qualified guess says that missing `docker.sock` was indeed the cause of [bug 990287](https://bugzilla.mozilla.org/show_bug.cgi?id=990287).
