### PR TITLE
Updated dockerode-process to new version with nicer log printing

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "debug": "^1.0.2",
     "dockerode": "^2.0.0",
     "dockerode-options": "^0.1.0",
-    "dockerode-process": "^0.5.0",
+    "dockerode-process": "^0.5.1",
     "dockerode-promise": "0.0.1",
     "jayschema": "^0.2.7",
     "middleware-object-hooks": "0.0.3",


### PR DESCRIPTION
I just pushed a new version of `dockerode-process` to get the fix I made... so that the first line after the message "ubuntu exists in the cache." isn't indented weird... It drives me crazy :)

Note, I haven't tested the dockerode-process, but I doubt/hope we didn't break anything with those commits... it's a long time since we've worked on it...
