### PR TITLE
Bug 1145564 - docker-worker: Fix payload.json schema to be valid

### DIFF
--- a/schemas/payload.js
+++ b/schemas/payload.js
@@ -84,9 +84,9 @@ module.exports = {
       "type": "number",
       "title": "Maximum run time in seconds",
       "description": "Maximum time the task container can run in seconds",
-      "multipleOf": "1.0",
-      "minimum": "1",
-      "maximum": "86400"
+      "multipleOf": 1.0,
+      "minimum": 1,
+      "maximum": 86400
     },
     "graphs": {
       "type": "array",


### PR DESCRIPTION
This fixes the following issue:
$ validate-schema payload.json
payload.json#/properties/maxRunTime: 86400 is not a valid maximum, must be a integer/number.
payload.json#/properties/maxRunTime: 1 is not a valid minimum, must be a integer/number.
payload.json#/properties/maxRunTime: 1.0 is not a valid multipleOf, must be a integer/number.