### PR TITLE
Bug 1056384 - Maxruntime adjustment

### DIFF
--- a/lib/features/artifacts.js
+++ b/lib/features/artifacts.js
@@ -71,7 +71,18 @@ export default class Artifacts {
 
       return;
     }
+
+    if (taskHandler.isAborted()) return;
     var tarExtract = tarStream.extract();
+
+    // If abort event is emitted, shut down the tarExtract stream which will cause
+    // the file to abort uploading and return back to the state handler.
+    taskHandler.on('abort', () => {
+      debug('Task has been aborted. Destroying tar stream.');
+      tarExtract.destroy();
+      tarExtract.emit('finish');
+    });
+
 
     // Begin unpacking the tar.
     contentStream.pipe(tarExtract);
@@ -142,7 +153,9 @@ export default class Artifacts {
       var res = yield waitForEvent(putReq, 'response');
 
       // If there was an error uploading the artifact note that in the result.
-      if (res.error) {
+      // Assume that if the task has been aborted, the upload will have failed
+      // and an error is expected
+      if (res.error && !this.taskHandler.isAborted()) {
         taskHandler.stream.write(taskHandler.fmtLog(
           'Artifact "%s" failed to upload "%s" error code: %s',
           name,

--- a/lib/features/artifacts.js
+++ b/lib/features/artifacts.js
@@ -72,17 +72,7 @@ export default class Artifacts {
       return;
     }
 
-    if (taskHandler.isAborted()) return;
     var tarExtract = tarStream.extract();
-
-    // If abort event is emitted, shut down the tarExtract stream which will cause
-    // the file to abort uploading and return back to the state handler.
-    taskHandler.on('abort', () => {
-      debug('Task has been aborted. Destroying tar stream.');
-      tarExtract.destroy();
-      tarExtract.emit('finish');
-    });
-
 
     // Begin unpacking the tar.
     contentStream.pipe(tarExtract);
@@ -139,11 +129,26 @@ export default class Artifacts {
       var putUrl =
         yield ctx.getPutUrl(taskHandler, entryName, expiry, contentType);
 
+      if (taskHandler.isAborted() || taskHandler.isCanceled()) {
+        tarExtract.destroy();
+        tarExtract.emit('finish');
+        return;
+      }
       // Put the artifact on the server.
       var putReq = request.put(putUrl).set({
         'Content-Length': contentLength,
         'Content-Type': contentType
       });
+
+      taskHandler.on('abort', () => {
+        // If abort event is emitted, shut down the tarExtract stream which will cause
+        // the file to abort uploading and return back to the state handler.
+        debug('Task has been aborted. Destroying tar stream and aborting request.');
+        putReq.abort();
+        tarExtract.destroy();
+        tarExtract.emit('finish');
+    });
+
 
       // Stream tar entry to request before ending the request
       stream.pipe(putReq);
@@ -155,7 +160,7 @@ export default class Artifacts {
       // If there was an error uploading the artifact note that in the result.
       // Assume that if the task has been aborted, the upload will have failed
       // and an error is expected
-      if (res.error && !this.taskHandler.isAborted()) {
+      if (res.error) {
         taskHandler.stream.write(taskHandler.fmtLog(
           'Artifact "%s" failed to upload "%s" error code: %s',
           name,

--- a/lib/states.js
+++ b/lib/states.js
@@ -45,18 +45,9 @@ export default class States {
   _invoke(method, task) {
     debug("taskId: %s at state: %s", task.status.taskId, method);
     let hooks = this.hooks.filter(hasMethod.bind(this, method));
-
-    return Promise.race([
-      this.stats.timeGen('tasks.time.states.' + method,
+    return this.stats.timeGen('tasks.time.states.' + method,
         Promise.all(hooks.map(hook => hook[method](task)))
-      ),
-      this.abort(task)
-    ]);
-
-  async abort(task) {
-    return new Promise((accept, reject) => {
-      task.on('abort', reject);
-    });
+    );
   }
 
   /**

--- a/lib/states.js
+++ b/lib/states.js
@@ -45,9 +45,18 @@ export default class States {
   _invoke(method, task) {
     debug("taskId: %s at state: %s", task.status.taskId, method);
     let hooks = this.hooks.filter(hasMethod.bind(this, method));
-    return this.stats.timeGen('tasks.time.states.' + method,
-      Promise.all(hooks.map(hook => hook[method](task)))
-    );
+
+    return Promise.race([
+      this.stats.timeGen('tasks.time.states.' + method,
+        Promise.all(hooks.map(hook => hook[method](task)))
+      ),
+      this.abort(task)
+    ]);
+
+  async abort(task) {
+    return new Promise((accept, reject) => {
+      task.on('abort', reject);
+    });
   }
 
   /**

--- a/lib/task.js
+++ b/lib/task.js
@@ -91,7 +91,7 @@ async function buildVolumeBindings(taskVolumeBindings, volumeCache, taskScopes) 
     }
   }
 
- let bindings = [];
+  let bindings = [];
   let caches = [];
 
   for (let volumeName in taskVolumeBindings) {
@@ -183,6 +183,7 @@ export default class Task extends EventEmitter {
    * @param {String} reason - Reason for aborting the test run (Example: worker-shutdown)
    */
   abort(reason, exception) {
+    // Emit event when state has changed so consumers can do The Right Thing.
     this.emit('abort', 'Task has been aborted');
     this.taskState = 'aborted';
     this.taskException = exception;
@@ -231,7 +232,7 @@ export default class Task extends EventEmitter {
     catch (e) {
       // If aborting the run and killing states for some reason fails, log
       // the error but continue moving on.
-      this.runtime.log('[error] states killed', {
+      this.runtime.log('[warning] Error killing states for aborted task', {
         taskId: this.status.taskId,
         runId: this.runId,
         err: e.toString(),
@@ -675,7 +676,6 @@ export default class Task extends EventEmitter {
 
     let success = exitCode === 0;
 
-    clearTimeout(runtimeTimeoutId);
 
     // XXX: Semi-hack to ensure all consumers of the docker proc stdout get the
     // entire contents. Ideally we could just wait for the end cb but that does
@@ -690,13 +690,15 @@ export default class Task extends EventEmitter {
       return await this.abortRun(this.taskState);
     }
 
-    // Extract any results from the hooks.
+    // Extract any results from the hooks.  If stopping the hooks for any reason
+    // results in an exception, fail the task.  This could happen when artifacts couldn't
+    // be uploaded or a graph extended.
     try {
       await this.states.stopped(this);
     }
     catch (e) {
       let lookupId = uuid.v4();
-      this.runtime.log('task exception', {
+      this.runtime.log('[exception] Error stopping states for running task.', {
         taskId: this.status.taskId,
         runId: this.runId,
         uuid: lookupId,
@@ -711,17 +713,37 @@ export default class Task extends EventEmitter {
       exitCode = -1;
     }
 
+    // Clear timeout and allow states to be killed.  Ideally the hooks are created in
+    // such a way that only minimal cleanup is done unrelated to the task and minimal
+    // chance of causing a task to hang.  This also allows logs to be uplaoded.
+    clearTimeout(runtimeTimeoutId);
+
+    // Still check if the run should be aborted so we ignore errors when killing states
+    // and also do not upload artifacts after a task has been canceled.  Currently
+    // artifacts can only be added for running jobs.
+    if (this.isCanceled() || this.isAborted()) {
+      return await this.abortRun(this.taskState);
+    }
+
     this.stream.write(this.logFooter(success, exitCode, this.taskStart, new Date()));
 
     // Wait for the stream to end entirely before killing remaining containers.
     await this.stream.end();
 
-    await this.states.killed(this);
-
-    // If the results validation failed we consider this task failure.
-    if (this.isCanceled() || this.isAborted()) {
-      return await this.abortRun(this.taskState);
+    // Killing of the states shouldn't be related to the task and just final cleanup.
+    // Log an issue with this but do not fail the task.
+    try {
+      await this.states.killed(this);
     }
+    catch (e) {
+      this.runtime.log('[warning] Error killing states for completed task', {
+        taskId: this.status.taskId,
+        runId: this.runId,
+        err: e.toString(),
+        stack: e.stack
+      });
+    }
+
     return success;
   }
 };

--- a/lib/task.js
+++ b/lib/task.js
@@ -736,7 +736,7 @@ export default class Task extends EventEmitter {
       await this.states.killed(this);
     }
     catch (e) {
-      this.runtime.log('[warning] Error killing states for completed task', {
+      this.runtime.log('[exception] Error killing states for completed task', {
         taskId: this.status.taskId,
         runId: this.runId,
         err: e.toString(),

--- a/lib/task.js
+++ b/lib/task.js
@@ -210,6 +210,7 @@ export default class Task extends EventEmitter {
    * @param {String} error - Option error to write to the stream prior to aborting
    */
   async abortRun(stat, error) {
+    let stat = stat;
     if (!this.isCanceled()) this.taskState = 'aborted';
 
     if (error) this.stream.write(error);
@@ -586,8 +587,8 @@ export default class Task extends EventEmitter {
       await this.states.created(this);
     }
     catch (e) {
-      return await this.abortRun(
-        'states_failed',
+      this.taskState = 'states_failed';
+      await this.abort(
         this.fmtLog(
           'Task was aborted because states could not be created ' +
           `successfully. Error: ${e}`

--- a/lib/task.js
+++ b/lib/task.js
@@ -1,6 +1,7 @@
 /**
 Handler of individual tasks beings at claim ends with posting task results.
 */
+import EventEmitter from 'events';
 import Debug from 'debug';
 import DockerProc from 'dockerode-process';
 import util from 'util';
@@ -17,7 +18,7 @@ import { scopeMatch } from 'taskcluster-base/utils';
 import waitForEvent from './wait_for_event';
 import _ from 'lodash';
 
-let debug = new Debug('runTask');
+let debug = new Debug('taskcluster-docker-worker:runTask');
 let wordwrap = new Wordwrap(0, 80, { hard: true });
 
 const PAYLOAD_SCHEMA =
@@ -90,7 +91,7 @@ async function buildVolumeBindings(taskVolumeBindings, volumeCache, taskScopes) 
     }
   }
 
-  let bindings = [];
+ let bindings = [];
   let caches = [];
 
   for (let volumeName in taskVolumeBindings) {
@@ -151,7 +152,7 @@ function buildDeviceBindings(devices, taskScopes) {
   return deviceBindings;
 }
 
-export default class Task {
+export default class Task extends EventEmitter {
   /**
   @param {Object} runtime global runtime.
   @param {Object} task id for this instance.
@@ -173,6 +174,143 @@ export default class Task {
 
     // states actions.
     this.states = buildStateHandlers(task, this.runtime.stats);
+  }
+
+  /**
+   * Aborts the running of the task.  This is similar to cancelling a task, but
+   * will allow time to upload artifacts and report the run as an exception instead.
+   *
+   * @param {String} reason - Reason for aborting the test run (Example: worker-shutdown)
+   */
+  abort(reason, exception) {
+    this.emit('abort', 'Task has been aborted');
+    this.taskState = 'aborted';
+    this.taskException = exception;
+    this.runtime.stats.increment('tasks.aborted');
+    this.runtime.log('abort task', {
+      taskId: this.status.taskId,
+      runId: this.runId,
+      reason: reason
+    });
+
+    if (this.dockerProcess) this.dockerProcess.kill();
+
+    this.stream.write(
+      this.fmtLog(`Task has been aborted prematurely. Reason: ${reason}`)
+    );
+  }
+
+  /**
+   * Aborts a run that is currently running or being prepared to run (pulling images,
+   * establishing states, etc).  This will optionally write an error to the stream
+   * and then write the footer and kill states.
+   *
+   * @param {String} stat - Name of the current state to be used when generating stats for killing states
+   * @param {String} error - Option error to write to the stream prior to aborting
+   */
+  async abortRun(stat, error) {
+    if (!this.isCanceled()) this.taskState = 'aborted';
+
+    if (error) this.stream.write(error);
+
+    // Ensure that the stream has completely finished.
+    await this.stream.end(this.logFooter(
+      false, // unsuccessful task
+      -1, // negative exit code indicates infrastructure errors usually.
+      this.taskStart, // duration details...
+      new Date()
+    ));
+
+    try {
+      // Run killed hook and record reason why we aborted
+      await this.runtime.stats.timeGen(
+        `tasks.time.states.killed-by-abort.${stat}`,
+        this.states.killed(this)
+      );
+    }
+    catch (e) {
+      // If aborting the run and killing states for some reason fails, log
+      // the error but continue moving on.
+      this.runtime.log('[error] states killed', {
+        taskId: this.status.taskId,
+        runId: this.runId,
+        err: e.toString(),
+        stack: e.stack
+      });
+    }
+
+    if (this.isAborted()) {
+      let queue = this.runtime.queue;
+      let reporter = this.taskException ? queue.reportException : queue.reportFailed;
+      let reportDetails = [this.status.taskId, this.runId];
+      if (this.taskException) reportDetails.push({ reason: this.taskException });
+
+      await reporter.apply(queue, reportDetails);
+    }
+
+    this.runtime.log('task resolved', {
+      taskId: this.status.taskId,
+      runId: this.runId,
+      taskState: this.taskState
+    });
+
+    return false;
+  }
+
+  /**
+   * Cancel the running of the task.  Task cancellation was performed by an external
+   * entity and has already been published to task-exception exchange.  This will
+   * kill the docker container that might be running, attempt to release resources
+   * that were linked, as well as prevent artifacts from uploading, which cannot
+   * be done after a run is resolved.
+   *
+   * @param {String} reason - Reason for cancellation
+   */
+  cancel(reason) {
+    this.taskState = 'canceled';
+    this.taskException = reason;
+
+    this.runtime.stats.increment('tasks.canceled');
+    this.runtime.log('cancel task', {
+      taskId: this.status.taskId, runId: this.runId
+    });
+
+    if (this.dockerProcess) this.dockerProcess.kill();
+
+    this.stream.write(this.fmtLog(CANCEL_ERROR));
+  }
+
+  /**
+  Clear next reclaim if one is pending...
+  */
+  clearClaimTimeout() {
+    if (this.claimTimeoutId) {
+      clearTimeout(this.claimTimeoutId);
+      this.claimTimeoutId = null;
+    }
+  }
+
+  /**
+   * Resolves a run that has completed and reports to the proper exchange.
+   *
+   * If a task has been canceled or aborted, abortRun() should be used since the
+   * run did not complete.
+   *
+   * @param {Boolean} success
+   */
+
+  async completeRun(success) {
+    let queue = this.runtime.queue;
+    let reporter = success ? queue.reportCompleted : queue.reportFailed;
+    let reportDetails = [this.status.taskId, this.runId];
+
+    await reporter.apply(queue, reportDetails);
+
+    this.runtime.log('task resolved', {
+      taskId: this.status.taskId,
+      runId: this.runId,
+      taskState: success ? 'completed' : 'failed'
+    });
   }
 
   /**
@@ -268,6 +406,29 @@ export default class Task {
     return wordwrap(str);
   }
 
+  isAborted() {
+    return this.taskState === 'aborted';
+  }
+
+  isCanceled() {
+    return this.taskState === 'canceled';
+  }
+
+  logFooter(success, exitCode, start, finish) {
+    // Human readable success/failure thing...
+    let humanSuccess = success ?
+      'Successful' :
+      'Unsuccessful';
+
+    // Yes, date subtraction yields a Number.
+    let duration = (finish - start) / 1000;
+
+    return this.fmtLog(
+      '%s task run with exit code: %d completed in %d seconds',
+      humanSuccess, exitCode, duration
+    );
+  }
+
   logHeader() {
     let header = this.fmtLog(
       'taskId: %s, workerId: %s',
@@ -287,21 +448,6 @@ export default class Task {
     return header + '\r\n';
   }
 
-  logFooter(success, exitCode, start, finish) {
-    // Human readable success/failure thing...
-    let humanSuccess = success ?
-      'Successful' :
-      'Unsuccessful';
-
-    // Yes, date subtraction yields a Number.
-    let duration = (finish - start) / 1000;
-
-    return this.fmtLog(
-      '%s task run with exit code: %d completed in %d seconds',
-      humanSuccess, exitCode, duration
-    );
-  }
-
   logSchemaErrors(prefix, errors) {
     return this.fmtLog(
       "%s format is invalid json schema errors:\n %s",
@@ -310,86 +456,18 @@ export default class Task {
   }
 
   /**
-   * Aborts a run that is currently running or being prepared to run (pulling images,
-   * establishing states, etc).  This will optionally write an error to the stream
-   * and then write the footer and kill states.
-   *
-   * @param {String} stat - Name of the current state to be used when generating stats for killing states
-   * @param {String} error - Option error to write to the stream prior to aborting
-   */
-  async abortRun(stat, error='') {
-    if (!this.isCanceled()) this.taskState = 'aborted';
+  Reclaim the current task and schedule the next reclaim...
+  */
+  async reclaimTask() {
+    this.runtime.log('issue reclaim');
+    this.runtime.stats.increment('tasks.reclaims');
+    this.claim = await this.runtime.stats.timeGen(
+      'tasks.time.reclaim',
+      this.runtime.queue.reclaimTask(this.status.taskId, this.runId)
+    );
 
-    this.runtime.stats.increment('tasks.aborted');
-
-    this.runtime.log('task aborted', {
-      taskId: this.status.taskId,
-      runId: this.runId,
-      exception: this.taskException || '',
-      err: error
-    });
-
-    if (error) this.stream.write(error);
-
-    // Ensure that the stream has completely finished.
-    await this.stream.end(this.logFooter(
-      false, // unsuccessful task
-      -1, // negative exit code indicates infrastructure errors usually.
-      this.taskStart, // duration details...
-      new Date()
-    ));
-
-    try {
-      // Run killed hook and record reason why we aborted
-      await this.runtime.stats.timeGen(
-        `tasks.time.states.killed-by-abort.${stat}`,
-        this.states.killed(this)
-      );
-    }
-    catch (e) {
-      // Do not throw, killing the states is a best effort here when aborting
-      debug(`Caught error while killing state handlers. ${e}`);
-    }
-
-
-    if (this.isAborted()) {
-      let queue = this.runtime.queue;
-      let reporter = this.taskException ? queue.reportException : queue.reportFailed;
-      let reportDetails = [this.status.taskId, this.runId];
-      if (this.taskException) reportDetails.push({ reason: this.taskException });
-
-      await reporter.apply(queue, reportDetails);
-    }
-
-    this.runtime.log('task resolved', {
-      taskId: this.status.taskId,
-      runId: this.runId,
-      taskState: this.taskState
-    });
-
-    return false;
-  }
-
-  /**
-   * Resolves a run that has completed and reports to the proper exchange.
-   *
-   * If a task has been canceled or aborted, abortRun() should be used since the
-   * run did not complete.
-   *
-   * @param {Boolean} success
-   */
-  async completeRun(success) {
-    let queue = this.runtime.queue;
-    let reporter = success ? queue.reportCompleted : queue.reportFailed;
-    let reportDetails = [this.status.taskId, this.runId];
-
-    await reporter.apply(queue, reportDetails);
-
-    this.runtime.log('task resolved', {
-      taskId: this.status.taskId,
-      runId: this.runId,
-      taskState: success ? 'completed' : 'failed'
-    });
+    this.runtime.log('issued reclaim', { claim: this.claim });
+    await this.scheduleReclaim(this.claim);
   }
 
   /**
@@ -419,21 +497,10 @@ export default class Task {
       }.bind(this), nextClaim);
   }
 
-  /**
-  Clear next reclaim if one is pending...
-  */
-  clearClaimTimeout() {
-    if (this.claimTimeoutId) {
-      clearTimeout(this.claimTimeoutId);
-      this.claimTimeoutId = null;
-    }
-  }
-
   setRuntimeTimeout(maxRuntime) {
     let stats = this.runtime.stats;
     let maxRuntimeMS = maxRuntime*1000;
     let runtimeTimeoutId = setTimeout(function() {
-      this.taskState = 'aborted';
       stats.increment('tasks.timed_out');
       stats.gauge('tasks.timed_out.max_run_time', this.task.payload.maxRunTime);
       this.runtime.log('task max runtime timeout', {
@@ -441,31 +508,12 @@ export default class Task {
         taskId: this.status.taskId,
         runId: this.runId
       });
-      // we don't wait for the promise to resolve just trigger kill here which
-      // will cause run to stop processing the task and give us an error
-      // exit code.
-      this.dockerProcess.kill();
-      this.stream.write(this.fmtLog(
-        'Task timeout after %d seconds. Force killing container.',
-        this.task.payload.maxRunTime
-      ));
+      let maxRunTime = this.task.payload.maxRunTime;
+      this.abort(
+        `Task timeout after ${maxRunTime} seconds. Force killing container.`
+      );
     }.bind(this), maxRuntimeMS);
     return runtimeTimeoutId;
-  }
-
-  /**
-  Reclaim the current task and schedule the next reclaim...
-  */
-  async reclaimTask() {
-    this.runtime.log('issue reclaim');
-    this.runtime.stats.increment('tasks.reclaims');
-    this.claim = await this.runtime.stats.timeGen(
-      'tasks.time.reclaim',
-      this.runtime.queue.reclaimTask(this.status.taskId, this.runId)
-    );
-
-    this.runtime.log('issued reclaim', { claim: this.claim });
-    await this.scheduleReclaim(this.claim);
   }
 
   async start() {
@@ -506,53 +554,6 @@ export default class Task {
     if (!this.isCanceled() && !this.isAborted()) await this.completeRun(success);
   }
 
-  isAborted() {
-    return this.taskState === 'aborted';
-  }
-
-  isCanceled() {
-    return this.taskState === 'canceled';
-  }
-
-  /**
-   * Aborts the running of the task.  This is similar to cancelling a task, but
-   * will allow time to upload artifacts and report the run as an exception instead.
-   *
-   * @param {String} reason - Reason for aborting the test run (Example: worker-shutdown)
-   */
-  abort(reason) {
-    this.taskState = 'aborted';
-    this.taskException = reason;
-    if (this.dockerProcess) this.dockerProcess.kill();
-
-    this.stream.write(
-      this.fmtLog(`Task has been aborted prematurely. Reason: ${reason}`)
-    );
-  }
-
-  /**
-   * Cancel the running of the task.  Task cancellation was performed by an external
-   * entity and has already been published to task-exception exchange.  This will
-   * kill the docker container that might be running, attempt to release resources
-   * that were linked, as well as prevent artifacts from uploading, which cannot
-   * be done after a run is resolved.
-   *
-   * @param {String} reason - Reason for cancellation
-   */
-  cancel(reason) {
-    this.taskState = 'canceled';
-    this.taskException = reason;
-
-    this.runtime.stats.increment('tasks.canceled');
-    this.runtime.log('cancel task', {
-      taskId: this.status.taskId, runId: this.runId
-    });
-
-    if (this.dockerProcess) this.dockerProcess.kill();
-
-    this.stream.write(this.fmtLog(CANCEL_ERROR));
-  }
-
   /**
   Primary handler for all docker related task activities this handles the
   launching/configuration of all tasks as well as the features for the given
@@ -561,6 +562,8 @@ export default class Task {
   @return {Boolean} success true/false for complete run.
   */
   async run() {
+    let runtimeTimeoutId = this.setRuntimeTimeout(this.task.payload.maxRunTime);
+
     this.taskState = 'running';
     this.taskStart = new Date();
     let stats = this.runtime.stats;
@@ -659,8 +662,6 @@ export default class Task {
     dockerProc.stdout.pipe(this.stream, {
       end: false
     });
-
-    let runtimeTimeoutId = this.setRuntimeTimeout(this.task.payload.maxRunTime);
 
     if (this.isCanceled() || this.isAborted()) {
       return await this.abortRun(this.taskState);

--- a/lib/task_listener.js
+++ b/lib/task_listener.js
@@ -44,7 +44,9 @@ export default class TaskListener extends EventEmitter {
             await this.pause();
             for(let state of this.runningTasks) {
               try {
-                state.handler.abort('worker-shutdown');
+                state.handler.abort(
+                  'Received spot termination notice.', 'worker-shutdown'
+                );
               }
               catch (e) {
                 debug('Caught error, but node is being terminated so continue on.');

--- a/test/integration/balrog_vpn_proxy_test.js
+++ b/test/integration/balrog_vpn_proxy_test.js
@@ -53,8 +53,8 @@ suite('balrog vpn proxy', () => {
 
   test('missing feature scope', async () => {
     let error;
-    worker.on('task aborted', (message) => {
-      error = message.err
+    worker.on('abort task', (message) => {
+      error = message.reason;
     });
 
     let result = await worker.postToQueue({
@@ -75,6 +75,7 @@ suite('balrog vpn proxy', () => {
     // Need to rely on looking at the logging from the worker because the logserve
     // container might not have created a logging artifact in time because of where
     // this check takes place.
+    assert.ok(error, 'Error message is missing');
     assert.ok(
       error.indexOf('Insufficient scopes to use') !== -1,
       'Error does not contain correct message'

--- a/test/integration/maxruntime_test.js
+++ b/test/integration/maxruntime_test.js
@@ -1,26 +1,106 @@
-suite('worker timeouts', function() {
-  var co = require('co');
-  var testworker = require('../post_task');
+import testworker from '../post_task';
+import DockerWorker from '../dockerworker';
+import TestWorker from '../testworker';
 
-  test('worker sleep more than maxRunTime', co(function* () {
-    var result = yield testworker({
+let worker;
+
+suite('worker timeouts', () => {
+  setup(async () => {
+    worker = new TestWorker(DockerWorker);
+    await worker.launch();
+  });
+
+  teardown(async () => {
+    await worker.terminate();
+  });
+
+  test('worker sleep more than maxRunTime', async () => {
+    let maxRunTime = 10;
+    let result = await worker.postToQueue({
       payload: {
         image:          'taskcluster/test-ubuntu',
         command:        [
           '/bin/bash', '-c', 'echo "Hello"; sleep 20; echo "done";'
         ],
-        features: {},
-        maxRunTime:         10
+        maxRunTime: maxRunTime
       }
     });
+ 
     // Get task specific results
     assert.equal(result.run.state, 'failed', 'task should have failed');
     assert.equal(result.run.reasonResolved, 'failed', 'task should have failed');
-    assert.ok(result.log.indexOf('Hello') !== -1);
-    assert.ok(result.log.indexOf('done') === -1);
+    assert.ok(result.log.includes('Hello'));
+    assert.ok(!result.log.includes('done'));
     assert.ok(
-      result.log.indexOf('[taskcluster] Task timeout') !== -1,
+      result.log.includes(`Reason: Task timeout after ${maxRunTime}`),
       'Task should contain logs about timeout'
     );
-  }));
+  });
+
+  test('run time exceeded before container starts', async () => {
+    // Theoretically 1 second should not be enough time between claiming the task
+    // and running it in a container.  This test might need to be modified or
+    // removed if proven to be unreliable.
+    let maxRunTime = 1;
+    let result = await worker.postToQueue({
+      payload: {
+        image:          'taskcluster/test-ubuntu',
+        command:        [
+          '/bin/bash', '-c', 'echo "Hello"; sleep 20; echo "done";'
+        ],
+        maxRunTime: maxRunTime,
+        features: {
+          taskclusterProxy: true
+        }
+      }
+    });
+
+    // Get task specific results
+    assert.equal(result.run.state, 'failed', 'task should have failed');
+    assert.equal(result.run.reasonResolved, 'failed', 'task should have failed');
+    let log = result.log;
+    assert.equal(JSON.parse(log).message, 'Artifact not found', 'Task was not aborted before states created');
+  });
+
+  test('task claimed after previous task timed out', async () => {
+    let maxRunTimeResult = await worker.postToQueue({
+      payload: {
+        image:          'taskcluster/test-ubuntu',
+        command:        [
+          '/bin/bash', '-c', 'echo "Hello"; sleep 20; echo "done";'
+        ],
+        maxRunTime: 10
+      }
+    });
+
+    // Let's make sure the task ran out of time first before moving on
+    assert.equal(maxRunTimeResult.run.state, 'failed', 'task should have failed');
+    console.log(maxRunTimeResult.log);
+    assert.ok(
+      maxRunTimeResult.log.includes(`Reason: Task timeout after 10`),
+      'Task should contain logs about timeout'
+    );
+
+    let successfulResult = await worker.postToQueue({
+      payload: {
+        image:          'taskcluster/test-ubuntu',
+        command:        [
+          '/bin/bash', '-c', 'echo "Hello"'
+        ],
+        maxRunTime: 60
+      }
+    });
+
+    assert.equal(
+      successfulResult.run.state,
+      'completed',
+      'Task was not completed successfully'
+    );
+
+    assert.equal(
+      maxRunTimeResult.run.workerId,
+      successfulResult.run.workerId,
+      'Tasks were not completed by the same workers'
+    );
+  });
 });


### PR DESCRIPTION
Max runtime should include killing/stopping states

If max run time is reached while stopping states (specifically artifact copy/upload), the state handler will abort and the task can clean up and resolve as an exception.