### PR TITLE
Use binary encoding for unarmored data

### DIFF
--- a/lib/private_key.js
+++ b/lib/private_key.js
@@ -99,7 +99,7 @@ PrivateKey.prototype = {
 
       var encryptedVarBuf = new Buffer(encryptedVar, 'base64');
       var armoredEncryptedVar =
-        openpgp.armor.encode(enums.armor.message, encryptedVarBuf.toString());
+        openpgp.armor.encode(enums.armor.message, encryptedVarBuf.toString('binary'));
 
       var encryptedVarMessage =
         openpgp.message.readArmored(armoredEncryptedVar);

--- a/test/integration/encrypted_env_variables.js
+++ b/test/integration/encrypted_env_variables.js
@@ -41,7 +41,7 @@ suite('encrypted private env variables', function() {
       var encryptMessage = openpgp.encryptMessage(pubKey.keys, message);
       return encryptMessage.then(function(encryptedMsg) {
         var unarmoredEncryptedData = openpgp.armor.decode(encryptedMsg).data;
-        var result = new Buffer(unarmoredEncryptedData).toString('base64');
+        var result = new Buffer(unarmoredEncryptedData, 'binary').toString('base64');
         return result;
       }).catch(function(error) {
         throw('Unable to encrypt data: ' + error);


### PR DESCRIPTION
I have been trying to figure out why GnuPG generated encrypted variables are not compatible with TC. 
Looks like when we try to convert binary data to base64 using `new Buffer(binaryData).toString('base64')` we implicitly use 'utf8' encoding instead of 'binary'.

You can visually compare the outputs of the same data using different base64 methods:

```javascript
var fs = require('fs');
var openpgp = require('openpgp');
var base64 = require('openpgp/src/encoding/base64');

var pubKey = openpgp.key.readArmored(fs.readFileSync('docker-worker-pub.pem', 'ascii'));

openpgp.encryptMessage(pubKey.keys, "hello").then(function(encryptedMessage){
  console.log(encryptedMessage);
  var unarmoredEncryptedData = openpgp.armor.decode(encryptedMessage).data;

  // Current TC method
  var bufferDefaultResult = new Buffer(unarmoredEncryptedData).toString('base64');
  // Suggested method
  var bufferBinaryResult = new Buffer(unarmoredEncryptedData, 'binary').toString('base64');
  // compare it to what is used in openpgp.js, ignore line splits
  var base64Result = base64.encode(unarmoredEncryptedData);

  console.log(bufferDefaultResult);
  console.log(bufferBinaryResult);
  console.log(base64Result);
});
```