### PR TITLE
Check for diskspace treshold when available capcity is 0

### DIFF
--- a/lib/gc.js
+++ b/lib/gc.js
@@ -216,27 +216,25 @@ GarbageCollector.prototype = {
       // each task its capable of claiming.  Images that are not running will be
       // removed if they are expired or if there is not enough diskspace remaining
       // for each available task the worker can claim.
-      if (this.capacity - this.taskListener.pending > 0) {
-        var exceedsThreshold = yield exceedsDiskspaceThreshold(this.dockerVolume,
-                                 this.diskspaceThreshold,
-                                 (this.capacity - this.taskListener.pending),
-                                 this.log);
-        if (exceedsThreshold) {
-          this.emit('gc:diskspace:warning',
-                    {message: 'Diskspace threshold reached. ' +
-                              'Removing all non-running images.'
-                    });
-        } else {
-          this.emit('gc:diskspace:info',
-                    {message: 'Diskspace threshold not reached. ' +
-                              'Removing only expired images.'
-                    });
-        }
-        yield this.removeUnusedImages(exceedsThreshold);
+      var exceedsThreshold = yield exceedsDiskspaceThreshold(this.dockerVolume,
+                               this.diskspaceThreshold,
+                               (this.capacity - this.taskListener.pending),
+                               this.log);
+      if (exceedsThreshold) {
+        this.emit('gc:diskspace:warning',
+                  {message: 'Diskspace threshold reached. ' +
+                            'Removing all non-running images.'
+                  });
+      } else {
+        this.emit('gc:diskspace:info',
+                  {message: 'Diskspace threshold not reached. ' +
+                            'Removing only expired images.'
+                  });
+      }
+      yield this.removeUnusedImages(exceedsThreshold);
 
-        for (var i = 0; i < this.managers.length; i++) {
-          yield this.managers[i].clear(exceedsThreshold);
-        }
+      for (var i = 0; i < this.managers.length; i++) {
+        yield this.managers[i].clear(exceedsThreshold);
       }
 
       this.log('garbage collection finished');

--- a/test/garbage_collection_test.js
+++ b/test/garbage_collection_test.js
@@ -446,4 +446,22 @@ suite('garbage collection tests', function () {
       clearTimeout(gc.sweepTimeoutId);
     })
   );
+
+  test('Garbage collection cycle occurs when available capacity is 0', co(function* () {
+    var testMarkedContainers = [];
+
+    var gc = new GarbageCollector({
+      capacity: 1,
+      log: log,
+      docker: docker,
+      dockerVolume: '/',
+      interval: 2 * 1000,
+      taskListener: { pending: 1 },
+      diskspaceThreshold: 500000 * 100000000,
+      imageExpiration: 5
+    });
+
+    yield waitForEvent(gc, 'gc:diskspace:warning');
+    clearTimeout(gc.sweepTimeoutId);
+ }));
 });


### PR DESCRIPTION
Even when available capacity is 0, the diskspace threshold check should
be performed on each GC interval.  This is a follow up to the previous
merged PR that implemented math.max() to ensure at least a capacity of 1
is checked but that would have affected only the task polling interval
because of this guard in GC.