### PR TITLE
updated to use docker hub registry

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,6 +12,6 @@ Vagrant.configure("2") do |config|
 SCRIPT
 
   config.vm.provision "shell", path: 'vagrant.sh'
-  config.vm.provision "docker", images: [], version: "1.4.1"
+  config.vm.provision "docker", images: [], version: "1.6.1"
 
 end

--- a/config/defaults.js
+++ b/config/defaults.js
@@ -6,7 +6,10 @@ module.exports = {
     // option with caution.
     // TODO: Consider killing the node after completing one task or locking down
     // in other ways.
-    allowPrivileged: false
+    allowPrivileged: false,
+    // Default registry to use when making authenticated image requests.  This
+    // is similar to what docker pull does when `docker pull ubuntu:14.10`.
+    defaultRegistry: 'registry.hub.docker.com'
   },
   // Hostname of this docker worker
   host: 'localhost',
@@ -22,7 +25,7 @@ module.exports = {
   taskclusterProxyImage: 'taskcluster/taskcluster-proxy:latest',
   taskclusterLogImage: 'taskcluster/livelog:v3',
   testdroidProxyImage: 'taskcluster/testdroid-proxy:0.0.6',
-  balrogVPNProxyImage: 'quay.io/mozillab2g/taskcluster-vpn-proxy:0.0.1',
+  balrogVPNProxyImage: 'taskclusterprivate/taskcluster-vpn-proxy:0.0.1',
 
   alivenessCheckInterval: 30000, // 30 seconds
 

--- a/config/defaults.js
+++ b/config/defaults.js
@@ -22,7 +22,7 @@ module.exports = {
   taskclusterProxyImage: 'taskcluster/taskcluster-proxy:latest',
   taskclusterLogImage: 'taskcluster/livelog:v3',
   testdroidProxyImage: 'taskcluster/testdroid-proxy:0.0.6',
-  balrogVPNProxyImage: 'taskclusterprivate/taskcluster-vpn-proxy:0.0.1',
+  balrogVPNProxyImage: 'quay.io/mozillab2g/taskcluster-vpn-proxy:0.0.1',
 
   alivenessCheckInterval: 30000, // 30 seconds
 

--- a/config/defaults.js
+++ b/config/defaults.js
@@ -19,10 +19,10 @@ module.exports = {
   isolatedContainers: false,
 
   // Image used to  create the taskcluster proxy container.
-  taskclusterProxyImage: 'quay.io/mozilla/taskcluster-proxy',
-  taskclusterLogImage: 'quay.io/mozilla/taskcluster-logserve',
-  testdroidProxyImage: 'quay.io/mozilla/testdroid-proxy:0.0.6',
-  balrogVPNProxyImage: 'quay.io/mozillab2g/taskcluster-vpn-proxy:0.0.1',
+  taskclusterProxyImage: 'taskcluster/taskcluster-proxy:latest',
+  taskclusterLogImage: 'taskcluster/livelog:v3',
+  testdroidProxyImage: 'taskcluster/testdroid-proxy:0.0.6',
+  balrogVPNProxyImage: 'taskclusterprivate/taskcluster-vpn-proxy:0.0.1',
 
   alivenessCheckInterval: 30000, // 30 seconds
 

--- a/lib/docker_image.js
+++ b/lib/docker_image.js
@@ -37,7 +37,8 @@ Image.prototype = {
       // strip empty parts...
       return !!part;
     });
-    return components.length === 3;
+
+    return components.length === 2 || components.length === 3;
   },
 
   /**
@@ -45,9 +46,13 @@ Image.prototype = {
 
   @return {Object|null} credentials or null...
   */
-  credentials: function(repositories) {
+  credentials: function(repositories, defaultRegistry='') {
     // We expect the image to be be checked via imageCanAuthenticate first.
+    // This could be user/image or host/user/image.  If only user/image, use
+    // default registry
     var parts = this.name.split('/');
+    if (parts.length === 2) parts.unshift(defaultRegistry);
+
     var registryHost = parts[0];
     var registryUser = parts[1];
     var result;

--- a/lib/pull_image_to_stream.js
+++ b/lib/pull_image_to_stream.js
@@ -48,7 +48,8 @@ export async function pullDockerImage(runtime, imageName, scopes, taskId, runId,
 
   let pullOptions = {};
   // See if any credentials apply from our list of registries...
-  let credentials = dockerImage.credentials(runtime.registries);
+  let defaultRegistry = runtime.dockerConfig.defaultRegistry;
+  let credentials = dockerImage.credentials(runtime.registries, defaultRegistry);
   if (credentials) {
     // Validate scopes on the image if we have credentials for it...
     if (!scopeMatch(scopes, IMAGE_SCOPE_PREFIX + dockerImageName)) {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "diskspace": "^0.1.7",
     "diveSync": "^0.3.0",
     "docker-image-parser": "^1.0.0",
-    "dockerode": "^2.1.1",
+    "dockerode": "2.1.2",
     "dockerode-options": "^0.1.0",
     "dockerode-process": "^0.6.0",
     "dockerode-promise": "0.0.1",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "diskspace": "^0.1.7",
     "diveSync": "^0.3.0",
     "docker-image-parser": "^1.0.0",
-    "dockerode": "2.1.2",
+    "dockerode": "^2.1.4",
     "dockerode-options": "^0.1.0",
     "dockerode-process": "^0.6.0",
     "dockerode-promise": "0.0.1",

--- a/taskgraph.json
+++ b/taskgraph.json
@@ -24,7 +24,7 @@
           "command": [
             "npm install && ./build.sh && ./test/docker-worker-test --this-chunk 1 --total-chunks 5"
           ],
-          "image": "quay.io/mozilla/worker-ci:0.0.2",
+          "image": "taskcluster/worker-ci:0.0.2",
           "maxRunTime": 3600,
           "capabilities": {
             "privileged": true,
@@ -59,7 +59,7 @@
           "command": [
             "npm install && ./build.sh && ./test/docker-worker-test --this-chunk 2 --total-chunks 5"
           ],
-          "image": "quay.io/mozilla/worker-ci:0.0.2",
+          "image": "taskcluster/worker-ci:0.0.2",
           "maxRunTime": 3600,
           "capabilities": {
             "privileged": true,
@@ -94,7 +94,7 @@
           "command": [
             "npm install && ./build.sh && ./test/docker-worker-test --this-chunk 3 --total-chunks 5"
           ],
-          "image": "quay.io/mozilla/worker-ci:0.0.2",
+          "image": "taskcluster/worker-ci:0.0.2",
           "maxRunTime": 3600,
           "capabilities": {
             "privileged": true,
@@ -129,7 +129,7 @@
           "command": [
             "npm install && ./build.sh && ./test/docker-worker-test --this-chunk 4 --total-chunks 5"
           ],
-          "image": "quay.io/mozilla/worker-ci:0.0.2",
+          "image": "taskcluster/worker-ci:0.0.2",
           "maxRunTime": 3600,
           "capabilities": {
             "privileged": true,
@@ -164,7 +164,7 @@
           "command": [
             "npm install && ./build.sh && ./test/docker-worker-test --this-chunk 5 --total-chunks 5"
           ],
-          "image": "quay.io/mozilla/worker-ci:0.0.2",
+          "image": "taskcluster/worker-ci:0.0.2",
           "maxRunTime": 3600,
           "capabilities": {
             "privileged": true,

--- a/test/images/ci/DOCKER_TAG
+++ b/test/images/ci/DOCKER_TAG
@@ -1,1 +1,1 @@
-quay.io/mozilla/worker-ci
+taskcluster/worker-ci


### PR DESCRIPTION
Updates docker feature images to use docker hub instead of quay.  Also updated to use default registry for images given in the form <user>:<image>:,tag>