### PR TITLE
Create ways of reliably inserting and removing running tasks

### DIFF
--- a/lib/gc.js
+++ b/lib/gc.js
@@ -219,7 +219,7 @@ GarbageCollector.prototype = {
       // for each available task the worker can claim.
       var exceedsThreshold = yield exceedsDiskspaceThreshold(this.dockerVolume,
                                this.diskspaceThreshold,
-                               (this.capacity - this.taskListener.pending),
+                               this.taskListener.availableCapacity,
                                this.log);
       if (exceedsThreshold) {
         this.emit('gc:diskspace:warning',

--- a/lib/shutdown_manager.js
+++ b/lib/shutdown_manager.js
@@ -89,9 +89,7 @@ export default class ShutdownManager extends EventEmitter {
     this.taskListener.on('working', this.onWorking);
 
     // Kick off the idle timer if we started in an idle state.
-    if (taskListener.pending === 0) {
-      this.onIdle();
-    }
+    if (taskListener.isIdle()) this.onIdle();
   }
 
   scheduleTerminationPoll() {

--- a/lib/task_listener.js
+++ b/lib/task_listener.js
@@ -212,23 +212,56 @@ export default class TaskListener extends EventEmitter {
     }
   }
 
+  addRunningTask(runningState) {
+    this.runningTasks.push(runningState);
+    this.incrementPending();
+  }
+
+  removeRunningTask(runningState) {
+    let taskIndex = this.runningTasks.findIndex((runningTask) => {
+      return (runningTask.taskId === runningState.taskId) &&
+        (runningTask.runId === runningState.runId)
+    });
+
+    if (taskIndex === -1) {
+      this.runtime.log('[warning] running task removal error', {
+        taskId: runningState.taskId,
+        runId: runningState.runId,
+        err: 'Could not find the task Id in the list of running tasks'
+      });
+      return;
+    }
+
+    this.cleanupRunningState(runningState);
+    this.runningTasks.splice(taskIndex, 1);
+    this.decrementPending();
+  }
+
   /**
   * Run task that has been claimed.
   */
   async runTask(claim) {
     try {
-      this.runtime.log('run task', { taskId: claim.status.taskId, runId: claim.runId });
-      this.incrementPending();
+      // Reference to state of this request...
+      let runningState = {
+        devices: {},
+        taskId: claim.status.taskId,
+        runId: claim.runId
+      };
+
+      this.runtime.log(
+        'run task',
+        {
+          taskId: runningState.taskId,
+          runId: runningState.runId
+        }
+      );
+
       // Fetch full task definition.
-      var task = await this.runtime.queue.task(claim.status.taskId);
+      var task = await this.runtime.queue.task(runningState.taskId);
 
       // Date when the task was created.
       var created = new Date(task.created);
-
-      // Reference to state of this request...
-      let runningState = {
-        devices: {}
-      };
 
       // Only record this value for first run!
       if (!claim.status.runs.length) {
@@ -261,17 +294,15 @@ export default class TaskListener extends EventEmitter {
       var taskHandler = new Task(this.runtime, task, claim, options);
       runningState.handler = taskHandler;
 
-      var taskIndex = this.runningTasks.push(runningState);
-      taskIndex = taskIndex-1;
+      this.addRunningTask(runningState)
 
       // Run the task and collect runtime metrics.
       await taskHandler.start();
-      this.decrementPending();
-      this.cleanupRunningState(runningState);
-      this.runningTasks.splice(taskIndex, 1);
+
+      this.removeRunningTask(runningState);
     }
     catch (e) {
-      this.runningTasks.splice(taskIndex, 1);
+      this.removeRunningTask(runningState);
       if (task) {
         this.runtime.log('task error', {
           taskId: claim.status.taskId,
@@ -286,8 +317,6 @@ export default class TaskListener extends EventEmitter {
           err: e
         });
       }
-      this.cleanupRunningState(runningState);
-      this.decrementPending();
     }
   }
 }

--- a/lib/task_listener.js
+++ b/lib/task_listener.js
@@ -50,7 +50,12 @@ export default class TaskListener extends EventEmitter {
           async () => {
             await this.pause();
             for(let state of this.runningTasks) {
-              state.handler.abort('worker-shutdown');
+              try {
+                state.handler.abort('worker-shutdown');
+              }
+              catch (e) {
+                debug('Caught error, but node is being terminated so continue on.');
+              }
               this.cleanupRunningState(state);
             }
           }();
@@ -109,6 +114,9 @@ export default class TaskListener extends EventEmitter {
   }
 
   get availableCapacity() {
+    // Note: Sometimes capacity could be zero (dynamic capacity changes based on
+    // shutdown and other factors) so subtracting runningTasks could result in a
+    // negative number, hence the use of at least returning 0.
     return Math.max(this.capacity - this.runningTasks.length, 0);
   }
 

--- a/lib/task_listener.js
+++ b/lib/task_listener.js
@@ -229,6 +229,7 @@ export default class TaskListener extends EventEmitter {
         runId: runningState.runId,
         err: 'Could not find the task Id in the list of running tasks'
       });
+      this.cleanupRunningState(runningState);
       return;
     }
 

--- a/lib/task_listener.js
+++ b/lib/task_listener.js
@@ -124,7 +124,6 @@ export default class TaskListener extends EventEmitter {
     // Do not claim tasks if not enough resources are available
     if (exceedsThreshold) return;
 
-    this.available
     let claims = await this.taskQueue.claimWork(this.availableCapacity);
     claims.forEach(this.runTask.bind(this));
   }
@@ -203,7 +202,7 @@ export default class TaskListener extends EventEmitter {
     this.runningTasks.push(runningState);
 
     // After going from an idle to a working state issue a 'working' event.
-    if (this.runningTasks === 1) {
+    if (this.runningTasks.length === 1) {
       this.emit('working', this);
     }
   }

--- a/lib/task_listener.js
+++ b/lib/task_listener.js
@@ -113,17 +113,18 @@ export default class TaskListener extends EventEmitter {
   }
 
   async getTasks() {
-    if (this.availabileCapacity === 0)  return;
+    if (this.availableCapacity === 0)  return;
 
     var exceedsThreshold = await exceedsDiskspaceThreshold(
       this.runtime.dockerVolume,
       this.runtime.capacityManagement.diskspaceThreshold,
-      this.availabileCapacity,
+      this.availableCapacity,
       this.runtime.log
     );
     // Do not claim tasks if not enough resources are available
     if (exceedsThreshold) return;
 
+    this.available
     let claims = await this.taskQueue.claimWork(this.availableCapacity);
     claims.forEach(this.runTask.bind(this));
   }

--- a/lib/task_listener.js
+++ b/lib/task_listener.js
@@ -109,12 +109,11 @@ export default class TaskListener extends EventEmitter {
   }
 
   get availableCapacity() {
-    return this.capacity - this.runningTasks.length;
+    return Math.max(this.capacity - this.runningTasks.length, 0);
   }
 
   async getTasks() {
-    // Number of tasks we could claim
-    if (this.availabileCapacity <= 0)  return;
+    if (this.availabileCapacity === 0)  return;
 
     var exceedsThreshold = await exceedsDiskspaceThreshold(
       this.runtime.dockerVolume,
@@ -125,7 +124,7 @@ export default class TaskListener extends EventEmitter {
     // Do not claim tasks if not enough resources are available
     if (exceedsThreshold) return;
 
-    let claims = await this.taskQueue.claimWork(this.availabileCapacity);
+    let claims = await this.taskQueue.claimWork(this.availableCapacity);
     claims.forEach(this.runTask.bind(this));
   }
 

--- a/lib/task_listener.js
+++ b/lib/task_listener.js
@@ -34,8 +34,6 @@ let cpuDeviceManager = new CpuDeviceManager();
 export default class TaskListener extends EventEmitter {
   constructor(runtime) {
     super();
-
-    this.pending = 0;
     this.runtime = runtime;
     this.capacity = runtime.capacity;
     this.runningTasks = [];
@@ -110,21 +108,24 @@ export default class TaskListener extends EventEmitter {
     return cancelListener;
   }
 
+  get availableCapacity() {
+    return this.capacity - this.runningTasks.length;
+  }
+
   async getTasks() {
     // Number of tasks we could claim
-    let availabileCapacity = this.capacity - this.pending;
-    if (availabileCapacity <= 0)  return;
+    if (this.availabileCapacity <= 0)  return;
 
     var exceedsThreshold = await exceedsDiskspaceThreshold(
       this.runtime.dockerVolume,
       this.runtime.capacityManagement.diskspaceThreshold,
-      availabileCapacity,
+      this.availabileCapacity,
       this.runtime.log
     );
     // Do not claim tasks if not enough resources are available
     if (exceedsThreshold) return;
 
-    let claims = await this.taskQueue.claimWork(availabileCapacity);
+    let claims = await this.taskQueue.claimWork(this.availabileCapacity);
     claims.forEach(this.runTask.bind(this));
   }
 
@@ -182,21 +183,7 @@ export default class TaskListener extends EventEmitter {
   }
 
   isIdle() {
-    return this.pending === 0;
-  }
-
-  incrementPending() {
-    // After going from an idle to a working state issue a 'working' event.
-    if (++this.pending === 1) {
-      this.emit('working', this);
-    }
-  }
-
-  decrementPending() {
-    this.pending--;
-    if (this.pending === 0) {
-      this.emit('idle', this);
-    }
+    return this.runningTasks.length === 0;
   }
 
   /**
@@ -214,7 +201,11 @@ export default class TaskListener extends EventEmitter {
 
   addRunningTask(runningState) {
     this.runningTasks.push(runningState);
-    this.incrementPending();
+
+    // After going from an idle to a working state issue a 'working' event.
+    if (this.runningTasks === 1) {
+      this.emit('working', this);
+    }
   }
 
   removeRunningTask(runningState) {
@@ -235,7 +226,8 @@ export default class TaskListener extends EventEmitter {
 
     this.cleanupRunningState(runningState);
     this.runningTasks.splice(taskIndex, 1);
-    this.decrementPending();
+
+    if (this.isIdle()) this.emit('idle', this);
   }
 
   /**

--- a/test/aws_metadata_test.js
+++ b/test/aws_metadata_test.js
@@ -1,4 +1,4 @@
-var app = require('./aws_metadata');
+var app = require('./fixtures/aws_metadata');
 var co = require('co');
 var http = require('http');
 var request = require('superagent-promise');

--- a/test/garbage_collection_test.js
+++ b/test/garbage_collection_test.js
@@ -54,7 +54,7 @@ suite('garbage collection tests', function () {
       log: log,
       docker: docker,
       interval: 2 * 1000,
-      taskListener: {pending: 1}
+      taskListener: { availableCapacity: 0 },
     });
 
     var container = yield docker.createContainer({Image: IMAGE});
@@ -79,7 +79,7 @@ suite('garbage collection tests', function () {
       log: log,
       docker: docker,
       interval: 2 * 1000,
-      taskListener: {pending: 1}
+      taskListener: { availableCapacity: 0 },
     });
 
     var container = yield docker.createContainer({Image: IMAGE,
@@ -109,7 +109,7 @@ suite('garbage collection tests', function () {
       log: log,
       docker: docker,
       interval: 2 * 1000,
-      taskListener: {pending: 1}
+      taskListener: { availableCapacity: 0 },
     });
 
       var container = yield docker.createContainer({Image: IMAGE});
@@ -140,7 +140,7 @@ suite('garbage collection tests', function () {
       log: log,
       docker: docker,
       interval: 2 * 1000,
-      taskListener: {pending: 1}
+      taskListener: { availableCapacity: 0 },
     });
       clearTimeout(gc.sweepTimeoutId);
 
@@ -172,7 +172,7 @@ suite('garbage collection tests', function () {
       docker: docker,
       dockerVolume: '/',
       interval: 2 * 1000,
-      taskListener: {pending: 1},
+      taskListener: { availableCapacity: 1 },
       diskspaceThreshold: 500000 * 100000000,
       imageExpiration: 5,
       containerExpiration: 5
@@ -212,7 +212,7 @@ suite('garbage collection tests', function () {
       docker: docker,
       dockerVolume: '/',
       interval: 2 * 1000,
-      taskListener: {pending: 1},
+      taskListener: { availableCapacity: 1 },
       diskspaceThreshold: 1 * 100000000,
       containerExpiration: 1
     });
@@ -253,7 +253,7 @@ suite('garbage collection tests', function () {
         docker: docker,
         dockerVolume: '/',
         interval: 2 * 1000,
-        taskListener: {pending: 1},
+        taskListener: { availableCapacity: 1 },
         diskspaceThreshold: 1 * 100000000,
         imageExpiration: 1,
         containerExpiration: 1
@@ -292,7 +292,7 @@ suite('garbage collection tests', function () {
         docker: docker,
         dockerVolume: '/',
         interval: 2 * 1000,
-        taskListener: {pending: 1},
+        taskListener: { availableCapacity: 1 },
         diskspaceThreshold: 5000000 * 100000000,
         imageExpiration: 1
       });
@@ -325,7 +325,7 @@ suite('garbage collection tests', function () {
       docker: docker,
       dockerVolume: '/',
       interval: 2 * 1000,
-      taskListener: {pending: 1},
+      taskListener: { availableCapacity: 1 },
       diskspaceThreshold: 1 * 100000000,
       imageExpiration: 5
     });
@@ -360,7 +360,7 @@ suite('garbage collection tests', function () {
       docker: docker,
       dockerVolume: '/',
       interval: 2 * 1000,
-      taskListener: {pending: 1},
+      taskListener: { availableCapacity: 1 },
       diskspaceThreshold: 500000 * 100000000,
       imageExpiration: 5
     });
@@ -408,7 +408,7 @@ suite('garbage collection tests', function () {
         log: log,
         docker: docker,
         interval: 2 * 1000,
-        taskListener: {pending: 1},
+        taskListener: { availableCapacity: 0 },
         containerExpiration: containerExpiration
       });
 
@@ -456,7 +456,7 @@ suite('garbage collection tests', function () {
       docker: docker,
       dockerVolume: '/',
       interval: 2 * 1000,
-      taskListener: { pending: 1 },
+      taskListener: { availableCapacity: 0 },
       diskspaceThreshold: 500000 * 100000000,
       imageExpiration: 5
     });

--- a/test/integration/shutdown_test.js
+++ b/test/integration/shutdown_test.js
@@ -9,6 +9,7 @@ suite('Shutdown on idle', function() {
 
   var worker;
   setup(co(function * () {
+    settings.cleanup();
     settings.billingCycleInterval(40);
     settings.configure({
       shutdown: {


### PR DESCRIPTION
CAnnot rely on the index position of a task because other tasks could be sliced before it adjusting the index position.  Look at task id and run ID to find the running task before cleaning up.