### PR TITLE
Cleanup states (allow links to specify env vars)

### DIFF
--- a/lib/features/balrog_vpn_proxy.js
+++ b/lib/features/balrog_vpn_proxy.js
@@ -129,7 +129,10 @@ export default class BalrogVPNProxy {
       }
     }
 
-    return [{ name: name, alias: ALIAS }];
+    return {
+      links: [{name, alias: ALIAS}],
+      env: {}
+    };
   }
 
   async killed(task) {

--- a/lib/features/taskcluster_proxy.js
+++ b/lib/features/taskcluster_proxy.js
@@ -71,7 +71,10 @@ export default class TaskclusterProxy {
       throw new Error('Failed to initialize taskcluster proxy service.')
     }
 
-    return [{ name: name, alias: ALIAS }];
+    return {
+      links: [{name, alias: ALIAS}],
+      env: {}
+    };
   }
 
   async killed(task) {

--- a/lib/features/testdroid_proxy.js
+++ b/lib/features/testdroid_proxy.js
@@ -74,6 +74,10 @@ export default class TestdroidProxy {
 
     this.host = host;
     return [{ name: name, alias: ALIAS }];
+    return {
+      links: [{name, alias: ALIAS}],
+      env: {}
+    };
   }
 
   async killed(task) {

--- a/lib/features/testdroid_proxy.js
+++ b/lib/features/testdroid_proxy.js
@@ -73,7 +73,6 @@ export default class TestdroidProxy {
     }
 
     this.host = host;
-    return [{ name: name, alias: ALIAS }];
     return {
       links: [{name, alias: ALIAS}],
       env: {}

--- a/lib/states.js
+++ b/lib/states.js
@@ -29,50 +29,68 @@ Each "state" in the lifetime is a well defined function:
 
 @constructor
 @param {Array[Object]} hooks for handling states in the task lifecycle.
+@param {Stat} stats object, see stat.js
 */
 export default class States {
-  constructor(hooks) {
+  constructor(hooks, stats) {
     assert.ok(Array.isArray(hooks), 'hooks is an array');
     this.hooks = hooks;
+    this.stats = stats;
   }
 
   /**
   Invoke all hooks with a particular method.
   @param {Task} task handler.
   */
-  async _invoke(method, task) {
+  _invoke(method, task) {
     let hooks = this.hooks.filter(hasMethod.bind(this, method));
-    return  await Promise.all(hooks.map(async (hook) => {
-      return await hook[method](task);
-    }));
+    return stats.timeGen('tasks.time.states.' + method,
+      Promise.all(hooks.map(hook => hook[method](task)))
+    );
   }
 
   /**
-  The "link" state is responsible for creating any dependant containers and
-  returning the name of the container to be "linked" with the task container.
+  The "link" state is responsible for creating any dependent containers and
+  returning the name of the container to be "linked" with the task container,
+  additionally it may also return over-writeable environment variables to
+  give to the task.
 
-  Each "hook" which contains a link method _must_ return an array in the
-  following format:
+  Each "hook" which contains a link method or wants to declare an env variable
+  _must_ return an object in the following format:
 
   ```js
-      [
+    {
+      links: [
         { name: 'container name', alias: 'alias in task container' }
       ]
+      env: {
+        'name-of-env-var':  'value of variable'
+      }
+    }
   ```
 
   All links are run in parallel then merged.
+  Note, that environment variables can be overwritten by task-specific
+  environment variables, or environment variables from other hooks.
 
   @param {Task} task handler.
-  @return {Array[Object]} list of link aliases.
+  @return {Object} object on the same form as returned by hook, see above.
   */
   async link(task) {
     // Build the list of linked containers...
-    var links = await this._invoke('link', task);
+    let results = await this._invoke('link', task);
 
-    // Flat map.
-    return links.reduce(function(result, current) {
-      return result.concat(current);
-    }, [])
+    // List of lists of links
+    let listsOfLinks = results.map(_.property('links')).filter(_.isArray);
+
+    // List of env objects
+    let listsOfEnvs = results.map(_.property('env')).filter(_.isObject);
+
+    // Merge env objects and flatten lists of links
+    return {
+      links:  _.flatten(listOfLinks),
+      env:    _.defaults.apply(_, listsOfEnvs)
+    };
   }
 
   /**

--- a/lib/states.js
+++ b/lib/states.js
@@ -1,6 +1,6 @@
 var assert = require('assert');
 var debug = require('debug')('taskcluster-docker-worker:states');
-var co = require('co');
+var _ = require('lodash');
 
 function hasMethod(method, input) {
   return typeof input[method] === 'function';
@@ -88,7 +88,7 @@ export default class States {
 
     // Merge env objects and flatten lists of links
     return {
-      links:  _.flatten(listOfLinks),
+      links:  _.flatten(listsOfLinks),
       env:    _.defaults.apply(_, listsOfEnvs)
     };
   }

--- a/lib/states.js
+++ b/lib/states.js
@@ -44,7 +44,7 @@ export default class States {
   */
   _invoke(method, task) {
     let hooks = this.hooks.filter(hasMethod.bind(this, method));
-    return stats.timeGen('tasks.time.states.' + method,
+    return this.stats.timeGen('tasks.time.states.' + method,
       Promise.all(hooks.map(hook => hook[method](task)))
     );
   }

--- a/lib/task.js
+++ b/lib/task.js
@@ -181,10 +181,10 @@ export default class Task {
   @param {Array[dockerode.Container]} [links] list of dockerode containers.
   @param {object} [baseEnv] Environment variables that can be overwritten.
   */
-  async dockerConfig(links, baseEnv) {
+  async dockerConfig(linkInfo) {
     let config = this.task.payload;
     // Allow task specific environment vars to overwrite those provided by hooks
-    let env = _.defaults({}, config.env || {}, baseEnv || {});
+    let env = _.defaults({}, config.env || {}, linkInfo.env || {});
 
     await this.runtime.privateKey.decryptEnvVariables(
       this.task.payload, this.status.taskId
@@ -228,8 +228,8 @@ export default class Task {
       procConfig.create.HostConfig['Devices'] = bindings;
     }
 
-    if (links) {
-      procConfig.create.HostConfig.Links = links.map(function(link) {
+    if (linkInfo.links) {
+      procConfig.create.HostConfig.Links = linkInfo.links.map(link => {
         return link.name + ':' + link.alias;
       });
     }
@@ -557,10 +557,10 @@ export default class Task {
 
     // Task log header.
     this.stream.write(this.logHeader());
-    let links, baseEnv;
+    let linkInfo = {};
     try {
       // Build the list of container links... and base environment variables
-      {links, env: baseEnv} = await this.states.link(this);
+      linkInfo = await this.states.link(this);
       // Hooks prior to running the task.
       await this.states.created(this);
     }
@@ -625,7 +625,7 @@ export default class Task {
 
     let dockerConfig;
     try {
-      dockerConfig = await this.dockerConfig(links, baseEnv);
+      dockerConfig = await this.dockerConfig(linkInfo);
     } catch (e) {
       let error = this.fmtLog('Docker configuration could not be ' +
         'created.  This may indicate an authentication error when validating ' +

--- a/lib/task.js
+++ b/lib/task.js
@@ -15,7 +15,7 @@ import getHostname from './util/hostname';
 import { pullDockerImage, IMAGE_ERROR } from './pull_image_to_stream';
 import { scopeMatch } from 'taskcluster-base/utils';
 import waitForEvent from './wait_for_event';
-
+import _ from 'lodash';
 
 let debug = new Debug('runTask');
 let wordwrap = new Wordwrap(0, 80, { hard: true });
@@ -52,8 +52,9 @@ function taskEnvToDockerEnv(env) {
 Convert the feature flags into a state handler.
 
 @param {Object} task definition.
+@param {Stat} stats object, see stat.js
 */
-function buildStateHandlers(task) {
+function buildStateHandlers(task, stats) {
   let handlers = [];
   let featureFlags = task.payload.features || {};
 
@@ -66,7 +67,7 @@ function buildStateHandlers(task) {
     }
   }
 
-  return new States(handlers);
+  return new States(handlers, stats);
 }
 
 /**
@@ -171,25 +172,29 @@ export default class Task {
     this.stream = new PassThrough();
 
     // states actions.
-    this.states = buildStateHandlers(task);
+    this.states = buildStateHandlers(task, this.runtime.stats);
   }
 
   /**
   Build the docker container configuration for this task.
 
   @param {Array[dockerode.Container]} [links] list of dockerode containers.
+  @param {object} [baseEnv] Environment variables that can be overwritten.
   */
-  async dockerConfig(links) {
+  async dockerConfig(links, baseEnv) {
     let config = this.task.payload;
-    let env = config.env || {};
-
-    // Universally useful environment variables describing the current task.
-    env.TASK_ID = this.status.taskId;
-    env.RUN_ID = this.runId;
+    // Allow task specific environment vars to overwrite those provided by hooks
+    let env = _.defaults({}, config.env || {}, baseEnv || {});
 
     await this.runtime.privateKey.decryptEnvVariables(
-        this.task.payload, this.status.taskId
+      this.task.payload, this.status.taskId
     );
+
+    // Universally useful environment variables describing the current task.
+    // Note: these environment variables cannot be overwritten by anyone, we
+    //       rely on these for self-validating tasks.
+    env.TASK_ID = this.status.taskId;
+    env.RUN_ID = this.runId;
 
     let privilegedTask = runAsPrivileged(this.task, this.runtime.dockerConfig.allowPrivileged);
 
@@ -318,7 +323,11 @@ export default class Task {
     ));
 
     try {
-      await this.runtime.stats.timeGen(`tasks.time.states.${stat}.killed`, this.states.killed(this));
+      // Run killed hook and record reason why we aborted
+      await this.runtime.stats.timeGen(
+        `tasks.time.states.killed-by-abort.${stat}`,
+        this.states.killed(this)
+      );
     }
     catch (e) {
       // Do not throw, killing the states is a best effort here when aborting
@@ -548,13 +557,12 @@ export default class Task {
 
     // Task log header.
     this.stream.write(this.logHeader());
-    let links;
+    let links, baseEnv;
     try {
-      // Build the list of container links...
-      links =
-        await stats.timeGen('tasks.time.states.linked', this.states.link(this));
+      // Build the list of container links... and base environment variables
+      {links, env: baseEnv} = await this.states.link(this);
       // Hooks prior to running the task.
-      await stats.timeGen('tasks.time.states.created', this.states.created(this));
+      await this.states.created(this);
     }
     catch (e) {
       return await this.abortRun(
@@ -617,7 +625,7 @@ export default class Task {
 
     let dockerConfig;
     try {
-      dockerConfig = await this.dockerConfig(links);
+      dockerConfig = await this.dockerConfig(links, baseEnv);
     } catch (e) {
       let error = this.fmtLog('Docker configuration could not be ' +
         'created.  This may indicate an authentication error when validating ' +
@@ -666,9 +674,7 @@ export default class Task {
 
     // Extract any results from the hooks.
     try {
-      await stats.timeGen(
-        'tasks.time.states.stopped', this.states.stopped(this)
-      );
+      await this.states.stopped(this);
     }
     catch (e) {
       let lookupId = uuid.v4();
@@ -692,7 +698,7 @@ export default class Task {
     // Wait for the stream to end entirely before killing remaining containers.
     await this.stream.end();
 
-    await stats.timeGen('tasks.time.states.killed', this.states.killed(this));
+    await this.states.killed(this);
 
     // If the results validation failed we consider this task failure.
     if (this.isCanceled() || this.isAborted()) {


### PR DESCRIPTION
  * Clean-up how stats are collected for `states.js` (this may have altered the names a bit)
  * Allow `links` hooks to specify environment variables (which may be overwritten by task-specific variables).

I think this should work, I didn't run test yet... Test takes 45min, so I'll do that later as I have more to play with right now...
Perhaps docker-worker CI will pick it up and run the tests for me.  * Clean-up how stats are collected for `states.js` (this may have altered the names a bit)
  * Allow `links` hooks to specify environment variables (which may be overwritten by task-specific variables).

I think this should work, I didn't run test yet... Test takes 45min, so I'll do that later as I have more to play with right now...
Perhaps docker-worker CI will pick it up and run the tests for me.