### PR TITLE
Ensure that data VOLUMES aren't leaked

### DIFF
--- a/lib/gc.js
+++ b/lib/gc.js
@@ -114,9 +114,17 @@ GarbageCollector.prototype = {
         var caches = this.markedContainers[containerId].caches;
 
         try {
-          // Even running containers should be removed otherwise shouldn't have
-          // been marked for removal.
-          yield c.remove({force: true});
+          yield c.remove({
+            // Even running containers should be removed otherwise shouldn't have
+            // been marked for removal.
+            force: true,
+            // Any data volumes created by container should be removed too.
+            // These can be created with VOLUME statement in dockerfile.
+            // Tasks should use cache folders for caching things, though
+            // VOLUME statements makes sense if you want a non-AUFS folder that
+            // isn't persistent (AUFS can be slow for file intensive work)
+            v: true
+          });
           delete this.markedContainers[containerId];
 
           this.emit('gc:container:removed', {


### PR DESCRIPTION
When using the `VOLUME` statement in dockerfile, docker will create a data volume for the container unless another folder is bind to the mount-point.

Hence, using `VOLUME` and mounting a cache folder is very sane. But at the moment people can create data volumes with `VOLUME` and this data volume will never be deleted. See [remote API - remove container](https://docs.docker.com/reference/api/docker_remote_api_v1.18/#remove-a-container). Docker docs elsewhere says if data volumes aren't removed with the container they can't be recovered or deleted (well one can find the file manually). 

There is really only few reason for people to use the `VOLUME` statement, but in the current setup, if they do we leak disk space. So this is an attack vector for bringing our nodes down.

The only use case for `VOLUME` is that you want a volume folder that isn't persisted between tasks. This makes sense if you're doing file intensive work load, as AUFS isn't super fast when it comes to writing... (or least so I've read somewhere in docker docs).

----
This should be tested, and land independently of other PRs I've filed.