### PR TITLE
Retry docker image pulls with exponential backoff

### DIFF
--- a/config/defaults.js
+++ b/config/defaults.js
@@ -20,6 +20,7 @@ module.exports = {
       type: undefined // device type (ex. 'flame')
     }
   },
+
   dockerConfig: {
     // Privileged mode will allow tasks to run with elevated privileges similar
     // to process running on the host.  The task containers will have access to
@@ -30,7 +31,14 @@ module.exports = {
     allowPrivileged: false,
     // Default registry to use when making authenticated image requests.  This
     // is similar to what docker pull does when `docker pull ubuntu:14.10`.
-    defaultRegistry: 'registry.hub.docker.com'
+    defaultRegistry: 'registry.hub.docker.com',
+    // Maximum number of attempts to make when pulling an image
+    maxAttempts: 5,
+    // Delay factor rand randomizationFactor used to computer randomized
+    // exponential backoff when attempting to retry docker pulls
+    delayFactor: 15 * 1000,
+    // Value between 0 and 1
+    randomizationFactor: 0.25
   },
 
   ssl: {

--- a/config/test.js
+++ b/config/test.js
@@ -4,6 +4,14 @@ module.exports = {
   testMode: true,
   createQueue: false,
 
+  dockerConfig: {
+    allowPrivileged: false,
+    defaultRegistry: 'registry.hub.docker.com',
+    maxAttempts: 5,
+    delayFactor: 100,
+    randomizationFactor: 0.25
+  },
+
   influx: {
     connectionString: process.env.INFLUX_CONNECTION_STRING || 'http://localhost',
     maxDelay: 1,

--- a/lib/pull_image_to_stream.js
+++ b/lib/pull_image_to_stream.js
@@ -2,6 +2,8 @@ import DockerImage from './docker_image';
 import dockerUtils from 'dockerode-process/utils';
 import Debug from 'debug';
 import { scopeMatch } from 'taskcluster-base/utils';
+import waitForEvent from './wait_for_event';
+import sleep from './util/sleep';
 
 let debug = Debug('pull_image');
 
@@ -14,17 +16,48 @@ export const IMAGE_ERROR = 'Pulling docker image "%s" has failed this may indica
                   'Error with the registry used or an authentication error ' +
                   'in the worker try pulling the image locally. \n Error %s';
 
+export async function pullImageStreamTo(docker, image, stream, options) {
+  // Settings for exponential backoff for retrying image pulls.
+  // Last attempt will be in a range between 6 and 10 minutes which is acceptable
+  // for an image pull.
+  let maxAttempts = 5;
+  let attempts = 0;
+  let delayFactor = 15 * 1000;
+  let randomizationFactor = 0.25;
+  let error;
 
-export function pullImageStreamTo(docker, image, stream, options) {
-  return new Promise(function(accept, reject) {
-    debug('pull image', image);
-    var downloadProgress =
+  while (attempts++ < maxAttempts) {
+    error = undefined;
+
+    debug(`pull image. Image: ${image} Attempts: ${attempts}`);
+    let downloadProgress =
       dockerUtils.pullImageIfMissing(docker, image, options);
 
-    downloadProgress.pipe(stream, { end: false });
-    downloadProgress.once('error', reject);
-    downloadProgress.once('end', accept);
-  });
+    downloadProgress.pipe(stream, {end: false});
+    downloadProgress.once('error', err => { error = err; });
+    await Promise.race([
+      waitForEvent(downloadProgress, 'error'),
+      waitForEvent(downloadProgress, 'end')
+    ]);
+
+    if (!error) {
+      return;
+    }
+
+    if (attempts === maxAttempts) {
+      throw new Error(error);
+    }
+
+    let delay = Math.pow(2, attempts - 1) * delayFactor;
+    delay = delay * (Math.random() * 2 * randomizationFactor + 1 - randomizationFactor);
+    debug(
+      `pull image failed ` +
+      `Next Attempt in: ${delay} ms` +
+      `Image: ${image} ` +
+      `Error: ${error} `
+    );
+    await sleep(delay);
+  }
 }
 
 export async function pullDockerImage(runtime, imageName, scopes, taskId, runId, stream) {

--- a/lib/pull_image_to_stream.js
+++ b/lib/pull_image_to_stream.js
@@ -16,47 +16,49 @@ export const IMAGE_ERROR = 'Pulling docker image "%s" has failed this may indica
                   'Error with the registry used or an authentication error ' +
                   'in the worker try pulling the image locally. \n Error %s';
 
-export async function pullImageStreamTo(docker, image, stream, options) {
-  // Settings for exponential backoff for retrying image pulls.
-  // Last attempt will be in a range between 6 and 10 minutes which is acceptable
-  // for an image pull.
-  let maxAttempts = 5;
+// Settings for exponential backoff for retrying image pulls.
+// Last attempt will be in a range between 6 and 10 minutes which is acceptable
+// for an image pull.
+const RETRY_CONFIG = {
+  maxAttempts: 5,
+  delayFactor: 15 * 1000,
+  randomizationFactor: 0.25
+}
+
+export async function pullImageStreamTo(docker, image, stream, options={}) {
+  let config = options.retryConfig || RETRY_CONFIG;
   let attempts = 0;
-  let delayFactor = 15 * 1000;
-  let randomizationFactor = 0.25;
-  let error;
 
-  while (attempts++ < maxAttempts) {
-    error = undefined;
-
-    debug(`pull image. Image: ${image} Attempts: ${attempts}`);
+  while (attempts++ < config.maxAttempts) {
+    debug('pull image. Image: %s Attempts: %s', image, attempts);
     let downloadProgress =
       dockerUtils.pullImageIfMissing(docker, image, options);
 
     downloadProgress.pipe(stream, {end: false});
-    downloadProgress.once('error', err => { error = err; });
-    await Promise.race([
-      waitForEvent(downloadProgress, 'error'),
-      waitForEvent(downloadProgress, 'end')
-    ]);
 
-    if (!error) {
-      return;
+    try {
+      await new Promise((accept, reject) => {
+        downloadProgress.once('error', reject);
+        downloadProgress.once('end', accept);
+      });
+    } catch (err) {
+      if (attempts >= config.maxAttempts) {
+        throw new Error(err);
+      }
+
+      let delay = Math.pow(2, attempts - 1) * config.delayFactor;
+      let randomizationFactor = config.randomizationFactor;
+      delay = delay * (Math.random() * 2 * randomizationFactor + 1 - randomizationFactor);
+      debug(
+        'pull image failed Next Attempt in: %s ms. Image: %s. %s, as JSON: %j',
+        delay,
+        image,
+        err,
+        err.stack
+      );
+
+      await sleep(delay);
     }
-
-    if (attempts === maxAttempts) {
-      throw new Error(error);
-    }
-
-    let delay = Math.pow(2, attempts - 1) * delayFactor;
-    delay = delay * (Math.random() * 2 * randomizationFactor + 1 - randomizationFactor);
-    debug(
-      `pull image failed ` +
-      `Next Attempt in: ${delay} ms` +
-      `Image: ${image} ` +
-      `Error: ${error} `
-    );
-    await sleep(delay);
   }
 }
 
@@ -70,33 +72,29 @@ export async function pullDockerImage(runtime, imageName, scopes, taskId, runId,
     image: dockerImageName
   });
 
-  // There are cases where we cannot authenticate a docker image based on how
-  // the name is formatted (such as `registry`) so simply pull here and do
-  // not check for credentials.
-  if (!dockerImage.canAuthenticate()) {
-    return await pullImageStreamTo(
-      runtime.docker, dockerImageName, stream
-    );
-  }
+  let pullOptions = {
+    retryConfig: runtime.dockerConfig
+  };
 
-  let pullOptions = {};
-  // See if any credentials apply from our list of registries...
-  let defaultRegistry = runtime.dockerConfig.defaultRegistry;
-  let credentials = dockerImage.credentials(runtime.registries, defaultRegistry);
-  if (credentials) {
-    // Validate scopes on the image if we have credentials for it...
-    if (!scopeMatch(scopes, IMAGE_SCOPE_PREFIX + dockerImageName)) {
-      throw new Error(
-        'Insufficient scopes to pull : "' + dockerImageName + '" try adding ' +
-        IMAGE_SCOPE_PREFIX + dockerImageName + ' to the .scopes array.'
-      );
+  if (dockerImage.canAuthenticate()) {
+    // See if any credentials apply from our list of registries...
+    let defaultRegistry = runtime.dockerConfig.defaultRegistry;
+    let credentials = dockerImage.credentials(runtime.registries, defaultRegistry);
+    if (credentials) {
+      // Validate scopes on the image if we have credentials for it...
+      if (!scopeMatch(scopes, IMAGE_SCOPE_PREFIX + dockerImageName)) {
+        throw new Error(
+          'Insufficient scopes to pull : "' + dockerImageName + '" try adding ' +
+          IMAGE_SCOPE_PREFIX + dockerImageName + ' to the .scopes array.'
+        );
+      }
+
+      // TODO: Ideally we would verify the authentication before allowing any
+      // pulls (some pulls just check if the image is cached) the reason being
+      // we have no way to invalidate images once they are on a machine aside
+      // from blowing up the entire machine.
+      pullOptions.authconfig = credentials;
     }
-
-    // TODO: Ideally we would verify the authentication before allowing any
-    // pulls (some pulls just check if the image is cached) the reason being
-    // we have no way to invalidate images once they are on a machine aside
-    // from blowing up the entire machine.
-    pullOptions.authconfig = credentials;
   }
 
   return await pullImageStreamTo(

--- a/lib/pull_image_to_stream.js
+++ b/lib/pull_image_to_stream.js
@@ -41,6 +41,7 @@ export async function pullImageStreamTo(docker, image, stream, options={}) {
         downloadProgress.once('error', reject);
         downloadProgress.once('end', accept);
       });
+      return;
     } catch (err) {
       if (attempts >= config.maxAttempts) {
         throw new Error(err);

--- a/test/volume_cache_test.js
+++ b/test/volume_cache_test.js
@@ -3,6 +3,7 @@ suite('volume cache test', function () {
   var GarbageCollector = require('../lib/gc');
   var createLogger = require('../lib/log');
   var debug = require('debug')('volumeCacheTest');
+  var devnull = require('dev-null');
   var docker = require('../lib/docker')();
   var waitForEvent = require('../lib/wait_for_event');
   var fs = require('fs');
@@ -31,7 +32,7 @@ suite('volume cache test', function () {
   var IMAGE = 'taskcluster/test-ubuntu';
 
   setup(co(function* () {
-    yield pullImage(docker, IMAGE, process.stdout);
+    yield pullImage(docker, IMAGE, devnull());
   }));
 
   teardown(function () {


### PR DESCRIPTION
Deployed this to the raptor worker type which was hitting this frequently.
Here is a second attempt made at downloading the livelog image and it succeeded:  https://papertrailapp.com/systems/92517734/events?centered_on_id=546077531615571975