### PR TITLE
Bug 1175315 - Add Proxy feature for the releng API

### DIFF
--- a/config/defaults.js
+++ b/config/defaults.js
@@ -41,6 +41,13 @@ module.exports = {
     randomizationFactor: 0.25
   },
 
+  features: {
+    relengAPIProxy: {
+      image: 'quay.io/djmitche/relengapi-proxy:0.0.2',
+      token: process.env.RELENG_API_TOKEN
+    }
+  },
+
   ssl: {
     certificate: '/etc/star_taskcluster-worker_net.crt',
     key: '/etc/star_taskcluster-worker_net.key'

--- a/deploy/template/etc/docker-worker.conf.json
+++ b/deploy/template/etc/docker-worker.conf.json
@@ -26,5 +26,11 @@
 
   "statelessHostname": {
     "secret": "{{statelessHostname.secret}}"
+  },
+
+  "features": {
+    "relengAPIProxy": {
+      "token": "{{relengAPIToken}}"
+    }
   }
 }

--- a/deploy/variables.js
+++ b/deploy/variables.js
@@ -138,5 +138,9 @@ module.exports = {
 
   'sslKeyLocation': {
     description: 'Location of SSL key for secure things like live logging'
+  },
+
+  'relengAPIToken': {
+    description: 'Token to be used with the Relengapi Proxy'
   }
 };

--- a/lib/features.js
+++ b/lib/features.js
@@ -88,6 +88,14 @@ const features = {
                  'capabilities or host volume mounts.',
     defaults: false,
     module: require('./features/dind')
+  },
+
+  relengAPIProxy: {
+    title: 'Releng API proxy service',
+    description: 'The Releng API proxy service allows tasks to talk to releng ' +
+                 'api using an authorization token based on the task\'s scopes',
+    defaults: false,
+    module: require('./features/releng_api_proxy')
   }
 };
 

--- a/lib/features/releng_api_proxy.js
+++ b/lib/features/releng_api_proxy.js
@@ -1,0 +1,75 @@
+/**
+This module handles the creation of the "relengapi" proxy container which
+allows tasks to talk directly to releng api over a http proxy which
+grants a particular permission level based on the task scopes.
+*/
+import waitForPort from '../wait_for_port';
+import { pullImageStreamTo } from '../pull_image_to_stream';
+
+// Alias used to link the proxy.
+const ALIAS = 'relengapi';
+
+// Maximum time in MS to wait for the proxy socket to become available.
+const INIT_TIMEOUT = 2000;
+
+export default class RelengAPIProxy {
+  constructor () {
+    /**
+    Docker container used in the linking process.
+    */
+    this.container = null;
+  }
+
+  async link(task) {
+    var docker = task.runtime.docker;
+
+    // Image name for the proxy container.
+    var image = task.runtime.features.relengAPIProxy.image;
+
+    await pullImageStreamTo(docker, image, process.stdout);
+
+    var cmd = [
+        `--relengapi-token=${task.runtime.features.relengAPIProxy.token}`,
+        task.status.taskId
+    ];
+
+    // create the container.
+    this.container = await docker.createContainer({
+      Image: image,
+
+      Tty: true,
+      AttachStdin: false,
+      AttachStdout: true,
+      AttachStderr: true,
+
+      Cmd: cmd
+    });
+
+    // Terrible hack to get container promise proxy.
+    this.container = docker.getContainer(this.container.id);
+
+    // TODO: In theory the output of the proxy might be useful consider logging
+    // this somehow.
+    await this.container.start({});
+
+    var inspect = await this.container.inspect();
+    var name = inspect.Name.slice(1);
+
+    try {
+      // wait for the initial server response...
+      await waitForPort(inspect.NetworkSettings.IPAddress, '80', INIT_TIMEOUT);
+    } catch (e) {
+      throw new Error('Failed to initialize releng API proxy service.');
+    }
+
+    return {
+      links: [{name, alias: ALIAS}],
+      env: {}
+    };
+  }
+
+  async killed(task) {
+    this.container.stop();
+    task.runtime.gc.removeContainer(this.container.id);
+  }
+}


### PR DESCRIPTION
This makes use of the relengapi proxy that Dustin created.  It was successfully used here:
https://tools.taskcluster.net/task-inspector/#ELmePgAbRz-W_7A_RUWmSw/0

This is probably the bare minimum stuff that's needed to get a feature like this landed.  Very basic.