### PR TITLE
Increasing the poll interval for workers nearing end of billing cycle

### DIFF
--- a/bin/worker.js
+++ b/bin/worker.js
@@ -220,7 +220,7 @@ async function main () {
 
   var runtime = new Runtime(config);
 
-  runtime.host = host;
+  runtime.hostManager = host;
 
   // Instantiate PrivateKey object for decrypting secure data
   // (currently encrypted environment variables)

--- a/bin/worker.js
+++ b/bin/worker.js
@@ -219,7 +219,7 @@ async function main () {
   config.gc.addManager(config.volumeCache);
 
   var runtime = new Runtime(config);
-  
+
   runtime.host = host;
 
   // Instantiate PrivateKey object for decrypting secure data

--- a/bin/worker.js
+++ b/bin/worker.js
@@ -240,7 +240,7 @@ async function main () {
   }
 
   // Build the listener and connect to the queue.
-  var taskListener = new TaskListener(runtime);
+  var taskListener = new TaskListener(host, runtime);
   runtime.gc.taskListener = taskListener;
   shutdownManager.observe(taskListener);
 

--- a/bin/worker.js
+++ b/bin/worker.js
@@ -219,6 +219,8 @@ async function main () {
   config.gc.addManager(config.volumeCache);
 
   var runtime = new Runtime(config);
+  
+  runtime.host = host;
 
   // Instantiate PrivateKey object for decrypting secure data
   // (currently encrypted environment variables)
@@ -240,7 +242,7 @@ async function main () {
   }
 
   // Build the listener and connect to the queue.
-  var taskListener = new TaskListener(host, runtime);
+  var taskListener = new TaskListener(runtime);
   runtime.gc.taskListener = taskListener;
   shutdownManager.observe(taskListener);
 

--- a/config/defaults.js
+++ b/config/defaults.js
@@ -127,7 +127,11 @@ module.exports = {
 
   taskQueue: {
     // Task queue will be polled on a frequent interval for new pending tasks
-    pollInterval: 30 * 1000,
+    pollInterval: 5 * 1000,
+    // Task queue will be polled slower near the end of a billing cycle by this many times
+    pollIntervalMultiplier: 12,
+    // Task polling will slow down in the last 1/x of a billing cycle
+    slowdownDivisor: 3,
     // If signed url for queue expires within now()+expiration, refresh queues
     expiration: 5 * 60 * 1000,
     // Number of times to retry requests to the task queue

--- a/config/defaults.js
+++ b/config/defaults.js
@@ -127,7 +127,7 @@ module.exports = {
 
   taskQueue: {
     // Task queue will be polled on a frequent interval for new pending tasks
-    pollInterval: 5 * 1000,
+    pollInterval: 30 * 1000,
     // If signed url for queue expires within now()+expiration, refresh queues
     expiration: 5 * 60 * 1000,
     // Number of times to retry requests to the task queue

--- a/config/defaults.js
+++ b/config/defaults.js
@@ -129,8 +129,22 @@ module.exports = {
     // Task queue will be polled on a frequent interval for new pending tasks
     pollInterval: 5 * 1000,
     // Task queue will be polled slower near the end of a billing cycle by this many times
+    // The higher this number is, the more likely we are to overkill on scaling down
+    // The lower this number is, the more likely we are to keep containers alive at lower than
+    // maximum capacity
+    // No particular reasoning for the choice of 12, just a trial for now
     pollIntervalMultiplier: 12,
     // Task polling will slow down in the last 1/x of a billing cycle
+    // Task run times have a distribution of something like 3/6/9min=Q1/2/3, so by reducing the number
+    // of tasks we grab in the last 60/3=20 min, we can increase the chances of a node dying
+    // if there is enough capacity to handle tasks without it
+    // If we increase this time (decrease the number here), it will decrease the efficiency
+    // of a node as it nears the end stages because there's a chance it could pick up two short tasks
+    // before it dies.
+    // If we decrease this time (increase the number here), it will cause more nodes to live past
+    // the next threshold (0:58:00, 1:58:00, etc) in exchange for increasing efficiency near end of life.
+    // Ideally we want to keep the period less than double the average task but more than the runtime of
+    // most (say, ~75%) of tasks.
     slowdownDivisor: 3,
     // If signed url for queue expires within now()+expiration, refresh queues
     expiration: 5 * 60 * 1000,

--- a/config/test.js
+++ b/config/test.js
@@ -13,6 +13,12 @@ module.exports = {
     randomizationFactor: 0.25
   },
 
+  taskQueue: {
+    pollInterval: 1000,
+    pollIntervalMultiplier: 4,
+    slowdownDivisor: 2
+  },
+
   influx: {
     maxDelay: 1,
     maxPendingPoints: 1,

--- a/lib/runtime.js
+++ b/lib/runtime.js
@@ -74,7 +74,7 @@ Runtime.prototype = {
   /**
   Host instance
   */
-  host: null
+  hostManager: null
 };
 
 module.exports = Runtime;

--- a/lib/runtime.js
+++ b/lib/runtime.js
@@ -1,5 +1,5 @@
 /**
-Holds all runtime configuration options for the worker with various convince 
+Holds all runtime configuration options for the worker with various convenience 
 methods.
 */
 var assert = require('assert');
@@ -69,7 +69,12 @@ Runtime.prototype = {
   /**
   Used to decrypt secure environment variables
   */
-  privateKey: null
+  privateKey: null,
+
+  /**
+  Host instance
+  */
+  host: null
 };
 
 module.exports = Runtime;

--- a/lib/shutdown_manager.js
+++ b/lib/shutdown_manager.js
@@ -8,7 +8,7 @@ export default class ShutdownManager extends EventEmitter {
   constructor(host, config) {
     super();
     this.idleTimeout = null;
-    this.host = host;
+    this.host = config.hostManager;
     this.config = config;
     this.stats = config.stats;
     this.nodeTerminationPoll = config.shutdown.nodeTerminationPoll || 5000;

--- a/lib/states.js
+++ b/lib/states.js
@@ -60,7 +60,7 @@ export default class States {
       {state: method}
     ).then(results => {
       if (errors.length > 0) {
-        throw new Error(errors.map(e => e.toString()).join(' | '))
+        throw new Error(errors.map(e => (e.toString() + e.stack)).join(' | '));
       }
       return results;
     });

--- a/lib/task_listener.js
+++ b/lib/task_listener.js
@@ -18,7 +18,7 @@ var DeviceManager = require('./devices/device_manager.js');
 @param {Configuration} config for worker.
 */
 export default class TaskListener extends EventEmitter {
-  constructor(runtime) {
+  constructor(host, runtime) {
     super();
     this.runtime = runtime;
     this.capacity = runtime.capacity;
@@ -26,6 +26,7 @@ export default class TaskListener extends EventEmitter {
     this.taskQueue = new TaskQueue(this.runtime);
     this.taskPollInterval = this.runtime.taskQueue.pollInterval;
     this.lastTaskEvent = Date.now();
+    this.host = host;
 
     this.deviceManager = new DeviceManager(runtime);
   }
@@ -180,6 +181,18 @@ export default class TaskListener extends EventEmitter {
               err: e,
               stack: e.stack
           });
+        }
+        let stats = {
+          uptime: this.host.billingCycleUptime(),
+          interval: this.host.billingCycleInterval()
+        };
+        let remainder = stats.interval - (stats.uptime % stats.interval);
+        if(remainder * this.runtime.taskQueue.slowdownDivisor > stats.interval) {
+          //slow down the polling because it's nearing the end of the billing cycle
+          this.taskPollInterval = this.runtime.taskQueue.pollInterval * this.runtime.taskQueue.pollIntervalMultiplier;
+        } else {
+          //speed it up
+          this.taskPollInterval = this.runtime.taskQueue.pollInterval;
         }
         this.scheduleTaskPoll();
       }();

--- a/lib/task_listener.js
+++ b/lib/task_listener.js
@@ -26,6 +26,7 @@ export default class TaskListener extends EventEmitter {
     this.taskQueue = new TaskQueue(this.runtime);
     this.taskPollInterval = this.runtime.taskQueue.pollInterval;
     this.lastTaskEvent = Date.now();
+    this.host = runtime.hostManager;
 
     this.deviceManager = new DeviceManager(runtime);
   }
@@ -182,8 +183,8 @@ export default class TaskListener extends EventEmitter {
           });
         }
         let stats = {
-          uptime: this.runtime.host.billingCycleUptime(),
-          interval: this.runtime.host.billingCycleInterval()
+          uptime: this.host.billingCycleUptime() || 0,
+          interval: this.host.billingCycleInterval() || 1
         };
         let remainder = stats.interval - (stats.uptime % stats.interval);
         if(remainder * this.runtime.taskQueue.slowdownDivisor > stats.interval) {

--- a/lib/task_listener.js
+++ b/lib/task_listener.js
@@ -187,12 +187,18 @@ export default class TaskListener extends EventEmitter {
           interval: this.host.billingCycleInterval() || 1
         };
         let remainder = stats.interval - (stats.uptime % stats.interval);
-        if(remainder * this.runtime.taskQueue.slowdownDivisor > stats.interval) {
+        if(remainder * this.runtime.taskQueue.slowdownDivisor < stats.interval) {
           //slow down the polling because it's nearing the end of the billing cycle
-          this.taskPollInterval = this.runtime.taskQueue.pollInterval * this.runtime.taskQueue.pollIntervalMultiplier;
+          if(this.taskPollInterval === this.runtime.taskQueue.pollInterval) {
+            this.runtime.log('polling', {"message": "polling interval slowed down"});
+            this.taskPollInterval = this.runtime.taskQueue.pollInterval * this.runtime.taskQueue.pollIntervalMultiplier;
+          }
         } else {
           //speed it up
-          this.taskPollInterval = this.runtime.taskQueue.pollInterval;
+          if(this.taskPollInterval !== this.runtime.taskQueue.pollInterval) {
+            this.runtime.log('polling', {"message": "polling interval sped up"});
+            this.taskPollInterval = this.runtime.taskQueue.pollInterval;
+          }
         }
         this.scheduleTaskPoll();
       }();

--- a/lib/task_listener.js
+++ b/lib/task_listener.js
@@ -183,8 +183,8 @@ export default class TaskListener extends EventEmitter {
           });
         }
         let stats = {
-          uptime: this.host.billingCycleUptime() || 0,
-          interval: this.host.billingCycleInterval() || 1
+          uptime: this.host.billingCycleUptime(),
+          interval: this.host.billingCycleInterval()
         };
         let remainder = stats.interval - (stats.uptime % stats.interval);
         if(remainder * this.runtime.taskQueue.slowdownDivisor < stats.interval) {

--- a/lib/task_listener.js
+++ b/lib/task_listener.js
@@ -18,7 +18,7 @@ var DeviceManager = require('./devices/device_manager.js');
 @param {Configuration} config for worker.
 */
 export default class TaskListener extends EventEmitter {
-  constructor(host, runtime) {
+  constructor(runtime) {
     super();
     this.runtime = runtime;
     this.capacity = runtime.capacity;
@@ -26,7 +26,6 @@ export default class TaskListener extends EventEmitter {
     this.taskQueue = new TaskQueue(this.runtime);
     this.taskPollInterval = this.runtime.taskQueue.pollInterval;
     this.lastTaskEvent = Date.now();
-    this.host = host;
 
     this.deviceManager = new DeviceManager(runtime);
   }
@@ -183,8 +182,8 @@ export default class TaskListener extends EventEmitter {
           });
         }
         let stats = {
-          uptime: this.host.billingCycleUptime(),
-          interval: this.host.billingCycleInterval()
+          uptime: this.runtime.host.billingCycleUptime(),
+          interval: this.runtime.host.billingCycleInterval()
         };
         let remainder = stats.interval - (stats.uptime % stats.interval);
         if(remainder * this.runtime.taskQueue.slowdownDivisor > stats.interval) {

--- a/lib/task_listener.js
+++ b/lib/task_listener.js
@@ -190,14 +190,22 @@ export default class TaskListener extends EventEmitter {
         if(remainder * this.runtime.taskQueue.slowdownDivisor < stats.interval) {
           //slow down the polling because it's nearing the end of the billing cycle
           if(this.taskPollInterval === this.runtime.taskQueue.pollInterval) {
-            this.runtime.log('polling', {"message": "polling interval slowed down"});
             this.taskPollInterval = this.runtime.taskQueue.pollInterval * this.runtime.taskQueue.pollIntervalMultiplier;
+            
+            this.runtime.log('polling', { message: 'polling interval adjusted',
+              oldInterval: this.runtime.taskQueue.pollInterval,
+              newInterval: this.runtime.taskQueue.pollInterval * this.runtime.taskQueue.pollIntervalMultiplier
+            });
           }
         } else {
           //speed it up
           if(this.taskPollInterval !== this.runtime.taskQueue.pollInterval) {
-            this.runtime.log('polling', {"message": "polling interval sped up"});
             this.taskPollInterval = this.runtime.taskQueue.pollInterval;
+            
+            this.runtime.log('polling', { message: 'polling interval adjusted',
+              oldInterval: this.runtime.taskQueue.pollInterval * this.runtime.taskQueue.pollIntervalMultiplier,
+              newInterval: this.runtime.taskQueue.pollInterval
+            });
           }
         }
         this.scheduleTaskPoll();

--- a/test/integration/task_polling_test.js
+++ b/test/integration/task_polling_test.js
@@ -112,7 +112,7 @@ suite('Task Polling', () => {
     await new Promise((accept, reject) => {
       worker.on('polling', data => {
         console.log(data.message);
-        if(data.message === 'polling interval sped up')
+        if(data.message === 'polling interval adjusted' && data.oldInterval > data.newInterval)
           accept();
       });
       setTimeout(reject, 10000);
@@ -131,7 +131,7 @@ suite('Task Polling', () => {
     await new Promise((accept, reject) => {
       worker.on('polling', data => {
         console.log(data.message);
-        if(data.message === 'polling interval slowed down')
+        if(data.message === 'polling interval adjusted' && data.oldInterval < data.newInterval)
           accept();
       });
       setTimeout(reject, 10000);

--- a/test/integration/task_polling_test.js
+++ b/test/integration/task_polling_test.js
@@ -45,7 +45,7 @@ suite('Task Polling', () => {
 
     await waitForEvent(worker, 'created task');
     let claimedTask = false;
-    worker.on('claim task', () => claimTask = true);
+    worker.on('claim task', () => claimedTask = true);
     let count = 0;
     // Wait for a few polling cycles and ensure a task hasn't been claimed and
     // proper alert has been logged

--- a/test/integration/task_polling_test.js
+++ b/test/integration/task_polling_test.js
@@ -109,14 +109,9 @@ suite('Task Polling', () => {
     await base.testing.sleep(6000);
 
     settings.billingCycleUptime(0);
-    await new Promise((accept, reject) => {
-      worker.on('polling', data => {
-        console.log(data.message);
-        if(data.message === 'polling interval adjusted' && data.oldInterval > data.newInterval)
-          accept();
-      });
-      setTimeout(reject, 10000);
-    });
+    let pollingMessage = await waitForEvent(worker, 'polling');
+    assert(pollingMessage.message ===  'polling interval adjusted' &&
+      pollingMessage.oldInterval > pollingMessage.newInterval)
   });
 
   test('task polling slows down', async () => {
@@ -128,13 +123,8 @@ suite('Task Polling', () => {
     await base.testing.sleep(6000);
 
     settings.billingCycleUptime(30);
-    await new Promise((accept, reject) => {
-      worker.on('polling', data => {
-        console.log(data.message);
-        if(data.message === 'polling interval adjusted' && data.oldInterval < data.newInterval)
-          accept();
-      });
-      setTimeout(reject, 10000);
-    });
+    let pollingMessage = await waitForEvent(worker, 'polling');
+        assert(pollingMessage.message ===  'polling interval adjusted' &&
+          pollingMessage.oldInterval < pollingMessage.newInterval)
   });
 });


### PR DESCRIPTION
I'm not sure how much of a change this will have, but I do know this:

On a workertype with 1 worker (of which there are very few), we are at worst adding 70 seconds of wait time. On a workertype with many workers, this will hopefully reduce the number of workers sitting around with low used capacity by allowing workers to pull in larger batches of tasks at once. Of course, this is speculation, because I don't know what changing the polling from like an average of 20 polls/second for a big workertype like b2gtest or flame-kk to 3 polls/second will do. It also slows polling after a while, allowing workers nearing the end of a billing cycle to have a higher chance of dying instead of picking up new tasks. Maybe it won't do much. Hopefully though, this lets workers shut down when they should be shutting down, maybe reducing our AWS bill by a smidgeon. 