### PR TITLE
Bug 1197788 - show root cause of "Failed to initialize releng API proxy service" in error log message

### DIFF
--- a/lib/features/releng_api_proxy.js
+++ b/lib/features/releng_api_proxy.js
@@ -59,7 +59,7 @@ export default class RelengAPIProxy {
       // wait for the initial server response...
       await waitForPort(inspect.NetworkSettings.IPAddress, '80', INIT_TIMEOUT);
     } catch (e) {
-      throw new Error('Failed to initialize releng API proxy service.');
+      throw new Error('Failed to initialize releng API proxy service due to: ' + e.name + ': ' + e.message);
     }
 
     return {


### PR DESCRIPTION
@gregarndt, This change is to log the root cause of the error when we get `Failed to initialize releng API proxy service` in [bug 1197788](https://bugzilla.mozilla.org/show_bug.cgi?id=1197788). One cause has been established (if a taskId begins with `-` character) but this appears not to be only cause (e.g. [this task](https://treeherder.mozilla.org/logviewer.html#?repo=mozilla-inbound&job_id=15881645)). I'm hoping this change will allow us to discover some other root cause(s). I haven't yet tested this change locally (I haven't yet set up relengapi integration etc for a dev environment etc).

Question: do you know if this logging change could break tbl integration / automated bug starring?

In general it seems like a good practice to log errors we catch, even if we throw a new one, just in case there is instance data in the error that might be useful. Therefore we should probably also check for this pattern elsewhere, and update logging if we find it.

Thanks in advance for your review! =)