### PR TITLE
Bug 1219612 - use task definition from claimTask response

### DIFF
--- a/lib/task_listener.js
+++ b/lib/task_listener.js
@@ -334,7 +334,7 @@ export default class TaskListener extends EventEmitter {
         }
       );
 
-      // Lookup full task definition in claim response.
+      // Look up full task definition in claim response.
       var task = claim.task
 
       // Date when the task was created.

--- a/lib/task_listener.js
+++ b/lib/task_listener.js
@@ -334,8 +334,8 @@ export default class TaskListener extends EventEmitter {
         }
       );
 
-      // Fetch full task definition.
-      var task = await this.runtime.queue.task(runningState.taskId);
+      // Lookup full task definition in claim response.
+      var task = claim.task
 
       // Date when the task was created.
       var created = new Date(task.created);


### PR DESCRIPTION
Depends on https://github.com/taskcluster/taskcluster-queue/pull/61 landing first (see [relevant line](https://github.com/taskcluster/taskcluster-queue/pull/61/files#diff-13bae93e5c75b1afda41787e8285918eR34)).