### PR TITLE
Include actual error when extending taskgraph fails

### DIFF
--- a/lib/features/extend_task_graph.js
+++ b/lib/features/extend_task_graph.js
@@ -83,7 +83,6 @@ export default class ExtendTaskGraph {
     }
 
     // Extend the graph!
-    // TODO: Add logging to indicate task graph extension...
     try {
       var result = await scheduler.extendTaskGraph(graphId, extension);
       taskHandler.stream.write(taskHandler.fmtLog(
@@ -93,7 +92,7 @@ export default class ExtendTaskGraph {
     } catch (error) {
       throw new Error(
         'Graph server error while extending task graph id ' + graphId + ' : ' +
-        error.message + ', ' + error.body
+        error.message + ', ' + JSON.stringify(error.body.error)
       );
     }
   }

--- a/test/integration/taskgraph_extension_test.js
+++ b/test/integration/taskgraph_extension_test.js
@@ -229,4 +229,84 @@ suite('Extend Task Graph', function() {
       'Task should have been marked as failed'
     );
   }));
+
+  test('Update graph with invalid task scopes', co(function* () {
+    var graphId = slugid.v4();
+    var primaryTaskId = slugid.v4();
+
+    var graphTask = Task.create({
+      taskGroupId: graphId,
+      schedulerId: 'task-graph-scheduler',
+      workerType: worker.workerType,
+      provisionerId: worker.provisionerId,
+      // Because this scope is not included in the scopes the graph has, extending
+      // the task graph will fail
+      scopes: ['this-is-a-bad-scope'],
+      metadata: {
+        description: 'testing',
+        source: 'http://mytest/',
+        owner: 'test@localhost.local'
+      },
+      payload: {
+        image: 'taskcluster/test-ubuntu',
+        command: cmd('echo "wooot custom!"'),
+        features: {},
+        artifacts: {},
+        maxRunTime: 5 * 60
+      }
+    });
+
+    var graph = {
+      tasks: [{
+        taskId: slugid.v4(),
+        label: EXTENSION_LABEL,
+        requires: [],
+        reruns: 0,
+        task: graphTask
+      }]
+    };
+
+    var json = JSON.stringify(graph);
+    var result = yield worker.postToScheduler(graphId, {
+      metadata: {
+        source: 'http://xfoobar.com'
+      },
+      scopes: [
+        'queue:define-task:' + worker.provisionerId + '/' + worker.workerType
+      ],
+      tasks: [{
+        taskId: primaryTaskId,
+        label: 'primary',
+        task: {
+          metadata: {
+            owner: 'tests@local.localhost'
+          },
+          payload: {
+            image: 'taskcluster/test-ubuntu',
+            command: cmd(
+              'echo \'' + json + '\' > /graph.json'
+            ),
+            features: {},
+            artifacts: {},
+            graphs: ['/graph.json'],
+            maxRunTime: 5 * 60
+          }
+        }
+      }]
+    });
+
+    var log = result[0].log;
+    assert.ok(
+      log.includes("Graph server error while extending task graph"),
+      'Task graph error not logged'
+    );
+    assert.ok(
+      log.includes('Authorization Failed') && log.includes('this-is-a-bad-scope'),
+      'Error message did not include authorization failed message'
+    );
+    assert.ok(
+      result[0].run.state === 'failed',
+      'Task should have been marked as failed'
+    );
+  }));
 });


### PR DESCRIPTION
Scheduler returns a JSON object when there is an error extending a task
graph.  This object appears as [object, object] in the log if nothing
special is done.