### PR TITLE
Bug 1221491 - Log the feature that could not be started/stopped

### DIFF
--- a/lib/features/artifacts.js
+++ b/lib/features/artifacts.js
@@ -16,6 +16,10 @@ import waitForEvent from '../wait_for_event';
 let debug = Debug('docker-worker:middleware:artifact_extractor');
 
 export default class Artifacts {
+  constructor() {
+    this.featureName = 'artifactHandler';
+  }
+
   async uploadArtifact(taskHandler, name, artifact) {
     let errors = [];
     let container = taskHandler.dockerProcess.container;

--- a/lib/features/bulk_log.js
+++ b/lib/features/bulk_log.js
@@ -16,13 +16,13 @@ var ARTIFACT_NAME = 'public/logs/terminal_bulk.log.gz';
 
 export default class BulkLog {
   constructor(artifact) {
-
+    this.featureName = 'bulkLogHandler';
     this.artifactName = artifact || ARTIFACT_NAME;
     this.file = new temporary.File();
     debug('Created BulkLog using tempfile: ' + this.file.path);
   }
 
-  created(task) {
+  async created(task) {
     // Eventually we want to save the content as gzip on s3 or azure so we
     // incrementally compress it via streams.
     var gzip = zlib.createGzip();

--- a/lib/features/dind.js
+++ b/lib/features/dind.js
@@ -20,6 +20,7 @@ const INIT_TIMEOUT = 30 * 1000;
 
 export default class DockerInDocker {
   constructor() {
+    this.featureName = 'dind';
     // dind-service container
     this.container = null;
     this.tmpFolder = path.join('/tmp', slugid.v4());
@@ -76,7 +77,7 @@ export default class DockerInDocker {
     };
   }
 
-  killed(task) {
+  async killed(task) {
     task.runtime.gc.removeContainer(this.container.id);
 
     // Remove temporary folder, this should be possible even though container

--- a/lib/features/docker_save.js
+++ b/lib/features/docker_save.js
@@ -12,6 +12,9 @@ import zlib from 'zlib';
 let debug = Debug('docker-worker:features:docker-save');
 
 export default class DockerSave {
+  constructor() {
+    this.featureName = 'dockerSave';
+  }
   //commits and uploads the docker image as an artifact
   async uploadContainer(task) {
     //temporary path for saved file

--- a/lib/features/extend_task_graph.js
+++ b/lib/features/extend_task_graph.js
@@ -18,7 +18,9 @@ async function drain (listener) {
 }
 
 export default class ExtendTaskGraph {
-  constructor () {}
+  constructor () {
+    this.featureName = 'extendTaskGraph';
+  }
 
   async extendTaskGraph(taskHandler, graphPath) {
     var task = taskHandler.task;

--- a/lib/features/interactive.js
+++ b/lib/features/interactive.js
@@ -17,6 +17,7 @@ const MAX_RANDOM_PORT_ATTEMPTS = 20;
 
 export default class WebsocketServer {
   constructor () {
+    this.featureName = 'dockerInteractive';
     let id = slugid.v4();
     this.path = '/' + id;
     this.lock = path.join('/tmp/', id + '.lock');

--- a/lib/features/local_live_log.js
+++ b/lib/features/local_live_log.js
@@ -24,6 +24,7 @@ let debug = Debug('taskcluster-docker-worker:features:local_live_log');
 // Alias used to link the proxy.
 export default class TaskclusterLogs {
   constructor() {
+    this.featureName = 'localLiveLog';
     /**
     Docker container used in the linking process.
     */

--- a/lib/features/releng_api_proxy.js
+++ b/lib/features/releng_api_proxy.js
@@ -14,6 +14,7 @@ const INIT_TIMEOUT = 2000;
 
 export default class RelengAPIProxy {
   constructor () {
+    this.featureName = 'relengAPIProxy';
     /**
     Docker container used in the linking process.
     */

--- a/lib/features/taskcluster_proxy.js
+++ b/lib/features/taskcluster_proxy.js
@@ -13,6 +13,7 @@ const INIT_TIMEOUT = 2000;
 
 export default class TaskclusterProxy {
   constructor () {
+    this.featureName = 'taskclusterProxy';
     /**
     Docker container used in the linking process.
     */

--- a/lib/features/testdroid_proxy.js
+++ b/lib/features/testdroid_proxy.js
@@ -16,6 +16,7 @@ const MISSING_PHONE_CONFIGURATION = 'Phone device configuration must be supplied
 
 export default class TestdroidProxy {
   constructor() {
+    this.featureName = 'testdroidProxy';
     /**
     Docker container used in the linking process.
     */

--- a/lib/states.js
+++ b/lib/states.js
@@ -53,9 +53,13 @@ export default class States {
     return this.stats.timeGen(
       'stateChange',
       Promise.all(
-        hooks.map(hook => hook[method](task))
-             .map(r => Promise.resolve(r))
-             .map(p => p.catch(err => errors.push(err)))
+        hooks.map(hook => {
+          return hook[method](task)
+            .then(info => { return info; })
+            .catch(err => {
+              errors.push(new Error(`Error calling '${method}' for ${hook.featureName} : ${err.message}`));
+            });
+        })
       ),
       {state: method}
     ).then(results => {

--- a/test/integration/balrog_vpn_proxy_test.js
+++ b/test/integration/balrog_vpn_proxy_test.js
@@ -67,6 +67,11 @@ suite('balrog vpn proxy', () => {
       result.log.includes('[taskcluster:error] Task was aborted because states'),
       'Error does not container message about states being aborted'
     );
+
+    assert.ok(
+      result.log.includes('Error calling \'link\' for balrogVPNProxy'),
+      'Error does not contain the name of the feature'
+    );
     assert.ok(
       result.log.includes('Insufficient scopes to use \'balrogVPNProxy\''),
       'Error does not contain message about insufficient scopes'


### PR DESCRIPTION
This should now output an error such as:
[taskcluster:error] Task was aborted because states could not be created successfully. Error linking balrogVPNProxy : Insufficient scopes to use 'balrogVPNProxy' feature.  Try adding docker-worker:feature:balrogVPNProxy to the .scopes array.