### PR TITLE
Add guard around starting a docker container

### DIFF
--- a/test/integration/container_startup_test.js
+++ b/test/integration/container_startup_test.js
@@ -1,0 +1,36 @@
+import assert from 'assert';
+
+import DockerWorker from '../dockerworker';
+import TestWorker from '../testworker';
+
+suite('container startup', () => {
+  let worker;
+
+  setup(async () => {
+    worker = new TestWorker(DockerWorker);
+    await worker.launch();
+  });
+
+  teardown(async () => {
+    await worker.terminate();
+  });
+
+  test('caught failure - invalid command', async () => {
+    let result = await worker.postToQueue({
+      payload: {
+        image: 'taskcluster/test-ubuntu',
+        command: [
+          'echo "Hello"'
+        ],
+        maxRunTime: 30
+      }
+    });
+
+    assert.equal(result.run.state, 'failed', 'task should be successful');
+    assert.equal(result.run.reasonResolved, 'failed', 'task should be successful');
+    assert.ok(
+      result.log.includes('Failure to properly start execution environment'),
+      'Error message was not written to the task log.'
+    );
+  });
+});


### PR DESCRIPTION
When a docker container fails to start up either due to a docker issue or bad command, the error was not getting caught properly, resulting the task logs not getting uploaded and task not being resolved until deadline was exceeded or machine was shutdown.
