### PR TITLE
Bug 1221661: add an allowPtrace feature

### DIFF
--- a/lib/features.js
+++ b/lib/features.js
@@ -112,6 +112,14 @@ const features = {
                  'Can be used for SSH-like access to docker containers.',
     defaults: false,
     module: require('./features/interactive.js')
+  },
+
+  allowPtrace: {
+    title: 'Allow ptrace within the container',
+    description: 'This allows you to use the Linux ptrace functionality inside the ' + 
+                 'container; it is otherwise disallowed by Docker\'s security policy. ',
+    defaults: false,
+    module: require('./features/allow_ptrace')
   }
 };
 

--- a/lib/features/allow_ptrace.js
+++ b/lib/features/allow_ptrace.js
@@ -1,0 +1,25 @@
+/**
+ * This feature adjusts the AppArmor profile to allow ptrace within a container.
+ * All of the interesting action takes place in `lib/task.js`.
+ */
+
+import { scopeMatch } from 'taskcluster-base/utils';
+
+// Prefix used in scope matching for docker-worker features
+const FEATURE_SCOPE_PREFIX = 'docker-worker:feature:';
+
+export default class AllowPtrace {
+  constructor() {
+    this.featureName = 'allowPtrace';
+  }
+
+  async link(task) {
+    let featureScope = FEATURE_SCOPE_PREFIX + this.featureName;
+    if (!scopeMatch(task.task.scopes, [[featureScope]])) {
+      throw new Error(
+        `Insufficient scopes to use '${this.featureName}' feature.  ` +
+        `Try adding ${featureScope} to the .scopes array.`
+      );
+    }
+  }
+}

--- a/test/dockerworker.js
+++ b/test/dockerworker.js
@@ -65,6 +65,12 @@ export default class DockerWorker {
       Cmd: [
         '/bin/bash', '-c',
          [
+          // mount the securityfs in the container so that we can access apparmor
+          'mount',
+          '-tsecurityfs',
+          'securityfs',
+          '/sys/kernel/security',
+          '&&',
           `${babel} /worker/bin/worker.js`,
           '--host test',
           '--worker-group', 'random-local-worker',
@@ -96,7 +102,8 @@ export default class DockerWorker {
 
       Binds: [
         util.format('%s:%s', path.resolve(__dirname, '..'), '/worker'),
-        '/tmp:/tmp'
+        '/tmp:/tmp',
+        '/etc/apparmor.d:/etc/apparmor.d',
       ],
     };
 

--- a/test/images/test/Dockerfile
+++ b/test/images/test/Dockerfile
@@ -5,6 +5,10 @@ RUN npm install -g babel@4.7.16
 RUN mkdir /hack_bins/
 ENV PATH /hack_bins/:$PATH
 
+# install AppArmor for the AA-related tests
+RUN apt-get update
+RUN apt-get install -y apparmor
+
 # hacks to ensure we can shutdown...
 COPY ./shutdown /hack_bins/shutdown
 RUN chmod u+x /hack_bins/shutdown

--- a/test/integration/allow_ptrace_test.js
+++ b/test/integration/allow_ptrace_test.js
@@ -1,0 +1,64 @@
+import assert from 'assert';
+import base from 'taskcluster-base'
+import Docker from 'dockerode-promise';
+import dockerOpts from 'dockerode-options';
+import DockerWorker from '../dockerworker';
+import fs from 'mz/fs';
+import https from 'https';
+import request from 'superagent-promise';
+import * as settings from '../settings';
+import tar from 'tar-fs';
+import TestWorker from '../testworker';
+import waitForEvent from '../../lib/wait_for_event';
+import Debug from 'debug';
+
+let debug = Debug('docker-worker:test:allow-ptrace-test');
+
+suite('allowPtrace feature', () => {
+  let worker;
+  setup(async () => {
+    worker = new TestWorker(DockerWorker);
+    await worker.launch();
+  });
+
+  teardown(async () => {
+    if (worker) {
+      await worker.terminate();
+      worker = null;
+    }
+  });
+
+  test('use ptrace in a container without allowPtrace -- task should fail', async () => {
+    let result = await worker.postToQueue({
+      payload: {
+        image: 'busybox',
+        command: ['/bin/sh', '-c', 'od -x /proc/$$/auxv'],
+        maxRunTime: 1 * 60
+      }
+    });
+
+    debug(result.run);
+    assert(result.run.state === 'failed', 'task should fail');
+    assert(result.run.reasonResolved === 'failed', 'task should fail');
+  });
+
+  test('use ptrace in a container with allowPtrace -- task should succeed', async () => {
+    let result = await worker.postToQueue({
+      scopes: [
+        'docker-worker:feature:allowPtrace',
+      ],
+      payload: {
+        image: 'busybox',
+        command: ['/bin/sh', '-c', 'od -x /proc/$$/auxv'],
+        features: {
+          allowPtrace: true,
+        },
+        maxRunTime: 1 * 60
+      }
+    });
+
+    debug(result.run);
+    assert(result.run.state === 'completed', 'task should not fail');
+    assert(result.run.reasonResolved === 'completed', 'task should not fail');
+  });
+});


### PR DESCRIPTION
This is currently only controlled by the feature, meaning it would work in any workerType and only be limited by the feature scope.  I think this is probably fine -- as discussed in the bug, even with this feature enabled, ptrace is limited to processes within the container both by the PID namespace (weak) and the AppArmor policy (strong).

Code is untested but seems to be syntactically correct.