### PR TITLE
Make worker vagrant environment more general purpose for users

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,10 @@
-<!-- START doctoc generated TOC please keep comment here to allow auto update -->
-<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-**Table of Contents**  *generated with [DocToc](http://doctoc.herokuapp.com/)*
-
 - [Docker Worker](#docker-worker)
   - [Requirements](#requirements)
   - [Usage](#usage)
     - [Configuration](#configuration)
     - [Directory Structure](#directory-structure)
+  - [Environment](#environment)
+    - [Loopback Devices](#loopback-devices)
   - [Running tests](#running-tests)
     - [Common problems](#common-problems)
   - [Deployment](#deployment)
@@ -15,7 +13,6 @@
     - [Block-Device Mapping](#block-device-mapping)
     - [Updating Schema](#updating-schema)
 
-<!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 # Docker Worker
 
@@ -37,7 +34,7 @@ are for hacking on the worker itself.
 
   - Node 0.12.x
   - Docker
-  - Packer (to build ami)
+  - Packer (to build AMI)
 
 ## Usage
 
@@ -59,7 +56,7 @@ for the docker worker in particular these are important:
 
   - `registries` registry credentials
 
-  - `statsd` credentials for the statsd server.
+  - `influx` connection string and settings for sending metrics to influx.
 
 ### Directory Structure
 
@@ -70,6 +67,24 @@ for the docker worker in particular these are important:
   - [/lib/task_listener.js - primary entrypoint of worker](/lib/task_listener.js)
   - [/lib/task.js - handler for individual tasks](/lib/task_listener.js)
   - [/lib/features/ - individual features for worker](/lib/features/)
+
+### Environment
+
+docker-worker runs in an Ubuntu environment with various packages and kernel modules
+installed.
+
+Within the root of the repo is a Vagrantfile and vagrant.sh script that simplifies
+creating a local environment that mimics the one uses in production.  This environment
+allows one to not only run the worker tests but also to run images used in TaskCluster
+in an environment similar to production without needing to configure special things
+on the host.
+
+#### Loopback Devices
+
+The v4l2loopback and snd-aloop kernel modules are installed to allow loopback audio/video
+devices to be available within tasks that require them.  For information on how to
+configure these modules like production, consult the [vagrant script](https://github.com/taskcluster/docker-worker/blob/master/vagrant.sh)
+used for creating a local environment.
 
 ## Running tests
 
@@ -146,9 +161,9 @@ are important.
 
   1. Building the [base](/deploy/packer/base.json) AMI. Do this when:
       - You need to add new apt packages.
-      
+
       - You need to update docker (see above).
-      
+
       - You need to run some expensive one-off installation.
 
       - You need to update ssl/gpg keys
@@ -167,9 +182,9 @@ are important.
 
   2. Building the [app](/deploy/packer/app.json) AMI. Do this when:
       - You want to deploy new code/features.
-      
+
       - You need to update diamond/statsd/configs (not packages).
-      
+
       Note: That just because you deploy an AMI does not mean anyone is
       using it.. Usually you need to also update a provisioner workerType with
       the new AMI id.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,9 +1,12 @@
 Vagrant.configure("2") do |config|
   config.vm.box = "phusion/ubuntu-14.04-amd64"
 
+  config.vm.synced_folder ENV['HOME'], ENV['HOME']
+
   # We need to configure docker to expose port 60366
   config.vm.provision "shell", inline: <<-SCRIPT
 
+  # Setup Taskcluster and Pulse Credentials if available
   echo 'export TASKCLUSTER_CLIENT_ID="#{ENV['TASKCLUSTER_CLIENT_ID']}"' >> /home/vagrant/.bash_profile
   echo 'export TASKCLUSTER_ACCESS_TOKEN="#{ENV['TASKCLUSTER_ACCESS_TOKEN']}"' >> /home/vagrant/.bash_profile
   echo 'export PULSE_USERNAME="#{ENV['PULSE_USERNAME']}"' >> /home/vagrant/.bash_profile

--- a/vagrant.sh
+++ b/vagrant.sh
@@ -1,6 +1,6 @@
 #! /bin/bash -vex
-sudo apt-get update
-sudo apt-get install -y lxc v4l2loopback-utils build-essential gstreamer0.10-plugins-ugly gstreamer0.10-plugins-good gstreamer0.10-plugins-bad
+
+sudo ln -s /vagrant /worker
 
 # Install node
 export NODE_VERSION=v0.12.4
@@ -8,16 +8,35 @@ cd /usr/local/ && \
   curl https://nodejs.org/dist/$NODE_VERSION/node-$NODE_VERSION-linux-x64.tar.gz | tar -xz --strip-components 1 && \
   node -v
 
+
+sudo apt-get update
+sudo apt-get install -y lxc build-essential jq
+
+# Install nice-to-haves
+sudo apt-get install -y jq
+
+# Install Video loopback devices
+sudo apt-get install -y \
+    v4l2loopback-utils \
+    gstreamer0.10-plugins-ugly \
+    gstreamer0.10-plugins-good \
+    gstreamer0.10-plugins-bad
+
+sh -c 'echo "v4l2loopback" >> /etc/modules'
+
 cat << EOF > /etc/modprobe.d/test-modules.conf
-options snd-aloop enable=1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1 index=0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29
 options v4l2loopback devices=100
 EOF
 
-sh -c 'echo "v4l2loopback" >> /etc/modules'
-sh -c 'echo "snd-aloop" >> /etc/modules'
-depmod
-
 sudo modprobe v4l2loopback
+
+# Install Audio loopback devices
+sh -c 'echo "snd-aloop" >> /etc/modules'
+
+cat << EOF > /etc/modprobe.d/test-modules.conf
+options snd-aloop enable=1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1 index=0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29
+EOF
 sudo modprobe snd-aloop
 
-sudo ln -s /vagrant /worker
+# Create dependency file
+depmod


### PR DESCRIPTION
Just some minor changes to the readme and vagrant files to make it clearer what is getting installed and that this environment is available.  Easier to point people at the vagrant.sh file now for configuring devices locally when they can't use the vagrant setup.