### PR TITLE
Bug 1237659: also build PV AMIs

### DIFF
--- a/deploy/packer/app.json
+++ b/deploy/packer/app.json
@@ -50,6 +50,21 @@
         "Revision":         "{{user `workerRevision`}}",
         "Base_AMI":         "{{user `sourceAMI`}}"
       }
+    },
+    {
+      "type":           "amazon-ebs",
+      "region":         "us-west-2",
+      "ami_regions":    ["us-west-1", "us-east-1"],
+      "source_ami":     "{{user `pvSourceAMI`}}",
+      "instance_type":  "m1.medium",
+      "ssh_username":   "ubuntu",
+      "ami_name":       "taskcluster-docker-worker-{{user `fsType`}}-PV-{{timestamp}}",
+      "tags": {
+        "OS_Version":       "Ubuntu",
+        "Release":          "Latest",
+        "Revision":         "{{user `workerRevision`}}",
+        "Base_AMI":         "{{user `pvSourceAMI`}}"
+      }
     }
   ],
 

--- a/deploy/packer/base.json
+++ b/deploy/packer/base.json
@@ -56,6 +56,20 @@
         "Release":    "Latest",
         "Revision":   "{{user `workerRevision`}}"
       }
+    },
+    {
+      "type": "amazon-ebs",
+      "region": "us-west-2",
+      "source_ami": "ami-47465826",
+      "ami_virtualization_type": "paravirtual",
+      "instance_type": "m1.medium",
+      "ssh_username": "ubuntu",
+      "ami_name": "taskcluster-docker-worker-base PV {{timestamp}}",
+      "tags": {
+        "OS_Version": "Ubuntu",
+        "Release":    "Latest",
+        "Revision":   "{{user `workerRevision`}}"
+      }
     }
   ],
 


### PR DESCRIPTION
The base AMI here is "ubuntu/images/ebs/ubuntu-trusty-14.04-amd64-server-20151218" which is the latest "ebs" image.  Per http://aws.amazon.com/ec2/previous-generation/ m1.mediums have 410G of non-SSD instance storage, so I didn't select either of the "ebs-ssd" or "ebs-io1" base AMIs.

I haven't tried running this since I lack the secrets.