### PR TITLE
Bug 1237663: use a newer kernel

### DIFF
--- a/deploy/packer/app.json
+++ b/deploy/packer/app.json
@@ -4,8 +4,8 @@
   "variables": {
     "npmPackage":          "",
     "templateContents":    "",
-    "hvmSourceAMI":        "ami-ba5349db",
-    "pvSourceAMI":         "ami-225c4643",
+    "hvmSourceAMI":        "ami-006a7061",
+    "pvSourceAMI":         "ami-966973f7",
     "fsType":              "",
     "workerRevision":      ""
   },

--- a/deploy/packer/app.json
+++ b/deploy/packer/app.json
@@ -4,8 +4,8 @@
   "variables": {
     "npmPackage":          "",
     "templateContents":    "",
-    "hvmSourceAMI":        "ami-75fce145",
-    "pvSourceAMI":         "ami-186e7579",
+    "hvmSourceAMI":        "ami-2cb6ad4d",
+    "pvSourceAMI":         "ami-feb5ae9f",
     "fsType":              "",
     "workerRevision":      ""
   },

--- a/deploy/packer/app.json
+++ b/deploy/packer/app.json
@@ -4,8 +4,8 @@
   "variables": {
     "npmPackage":          "",
     "templateContents":    "",
-    "hvmSourceAMI":        "ami-eaafb48b",
-    "pvSourceAMI":         "ami-44a9b225",
+    "hvmSourceAMI":        "ami-ba5349db",
+    "pvSourceAMI":         "ami-225c4643",
     "fsType":              "",
     "workerRevision":      ""
   },

--- a/deploy/packer/app.json
+++ b/deploy/packer/app.json
@@ -4,8 +4,8 @@
   "variables": {
     "npmPackage":          "",
     "templateContents":    "",
-    "hvmSourceAMI":        "ami-2cb6ad4d",
-    "pvSourceAMI":         "ami-feb5ae9f",
+    "hvmSourceAMI":        "ami-eaafb48b",
+    "pvSourceAMI":         "ami-44a9b225",
     "fsType":              "",
     "workerRevision":      ""
   },

--- a/deploy/packer/base.json
+++ b/deploy/packer/base.json
@@ -62,7 +62,7 @@
       "type": "amazon-ebs",
       "name": "pv-builder",
       "region": "us-west-2",
-      "source_ami": "ami-47465826",
+      "source_ami": "ami-7f89a64f",
       "ami_virtualization_type": "paravirtual",
       "instance_type": "m1.medium",
       "ssh_username": "ubuntu",

--- a/deploy/packer/base/scripts/packages.sh
+++ b/deploy/packer/base/scripts/packages.sh
@@ -80,7 +80,7 @@ sudo apt-get update -y
 }
 
 ## upgrade the kernel, along with extra (which adds AUFS support)
-KERNEL_VER=3.19.0-43-generic
+KERNEL_VER=4.2.0-23-generic
 sudo apt-get install -y \
     linux-image-${KERNEL_VER} \
     linux-headers-${KERNEL_VER} \

--- a/deploy/packer/base/scripts/packages.sh
+++ b/deploy/packer/base/scripts/packages.sh
@@ -106,15 +106,30 @@ initrd          /boot/initrd.img-${KERNEL_VER}
 EOF
 
 ## Add the docker repo and update to pick it up
-sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 36A1D7869245C8950F966E92D8576A8BA88D21E9
-sudo sh -c "echo deb https://get.docker.io/ubuntu docker main\
+sudo apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
+sudo sh -c "echo deb https://apt.dockerproject.org/repo ubuntu-trusty main\
 > /etc/apt/sources.list.d/docker.list"
 sudo apt-get update -y
 
 ## Install all the other packages
-sudo apt-get install -y lxc-docker-1.6.1 btrfs-tools lvm2 curl build-essential \
-  git-core pbuilder python-mock python-configobj \
-  python-support cdbs python-pip jq rsyslog-gnutls openvpn lxc
+DOCKER_VER=1.9.1-0~trusty
+sudo apt-get install -y \
+  docker-engine=$DOCKER_VER \
+  btrfs-tools \
+  lvm2 \
+  curl \
+  build-essential \
+  git-core \
+  pbuilder \
+  python-mock \
+  python-configobj \
+  python-support \
+  cdbs \
+  python-pip \
+  jq \
+  rsyslog-gnutls \
+  openvpn \
+  lxc
 
 ## Install v4l2loopback; the version avalable from Ubuntu is too old for this kernel
 V4L2LOOPBACK_VER=0.9.1

--- a/deploy/packer/base/scripts/packages.sh
+++ b/deploy/packer/base/scripts/packages.sh
@@ -87,6 +87,24 @@ sudo apt-get install -y \
     linux-image-extra-${KERNEL_VER} \
     dkms
 
+# On paravirtualized instances, PV-GRUB looks at /boot/grub/menu.lst, which is different from the
+# /boot/grub/grub.cfg that dpkg just updated.  So we have to update menu.list manually.
+cat <<EOF | sudo tee /boot/grub/menu.lst >&2
+default         0
+timeout         0
+hiddenmenu
+
+title           Ubuntu 14.04.2 LTS, kernel ${KERNEL_VER}
+root            (hd0)
+kernel          /boot/vmlinuz-${KERNEL_VER} root=LABEL=cloudimg-rootfs ro console=hvc0
+initrd          /boot/initrd.img-${KERNEL_VER}
+
+title           Ubuntu 14.04.2 LTS, kernel ${KERNEL_VER} (recovery mode)
+root            (hd0)
+kernel          /boot/vmlinuz-${KERNEL_VER} root=LABEL=cloudimg-rootfs ro  single
+initrd          /boot/initrd.img-${KERNEL_VER}
+EOF
+
 ## Add the docker repo and update to pick it up
 sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 36A1D7869245C8950F966E92D8576A8BA88D21E9
 sudo sh -c "echo deb https://get.docker.io/ubuntu docker main\

--- a/deploy/packer/base/scripts/packages.sh
+++ b/deploy/packer/base/scripts/packages.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-set -v -e -x
+set -e -x
 
 lsb_release -a
 
@@ -8,22 +8,104 @@ lsb_release -a
 sudo groupadd docker
 sudo usermod -a -G docker $USER
 
+# For reasons that aren't at all clear, packer, or cloud-init, or very
+# predictable cosmic rays obliterate sources.list for paravirtualized AMIs.  So
+# we put it back.
+cat <<'EOF' | sudo tee /etc/apt/sources.list >&2
+## Note, this file is written by cloud-init on first boot of an instance
+## modifications made here will not survive a re-bundle.
+## if you wish to make changes you can:
+## a.) add 'apt_preserve_sources_list: true' to /etc/cloud/cloud.cfg
+##     or do the same in user-data
+## b.) add sources in /etc/apt/sources.list.d
+## c.) make changes to template file /etc/cloud/templates/sources.list.tmpl
+#
+
+# See http://help.ubuntu.com/community/UpgradeNotes for how to upgrade to
+# newer versions of the distribution.
+deb http://us-west-2.ec2.archive.ubuntu.com/ubuntu/ trusty main restricted
+deb-src http://us-west-2.ec2.archive.ubuntu.com/ubuntu/ trusty main restricted
+
+## Major bug fix updates produced after the final release of the
+## distribution.
+deb http://us-west-2.ec2.archive.ubuntu.com/ubuntu/ trusty-updates main restricted
+deb-src http://us-west-2.ec2.archive.ubuntu.com/ubuntu/ trusty-updates main restricted
+
+## N.B. software from this repository is ENTIRELY UNSUPPORTED by the Ubuntu
+## team. Also, please note that software in universe WILL NOT receive any
+## review or updates from the Ubuntu security team.
+deb http://us-west-2.ec2.archive.ubuntu.com/ubuntu/ trusty universe
+deb-src http://us-west-2.ec2.archive.ubuntu.com/ubuntu/ trusty universe
+deb http://us-west-2.ec2.archive.ubuntu.com/ubuntu/ trusty-updates universe
+deb-src http://us-west-2.ec2.archive.ubuntu.com/ubuntu/ trusty-updates universe
+
+## N.B. software from this repository is ENTIRELY UNSUPPORTED by the Ubuntu 
+## team, and may not be under a free licence. Please satisfy yourself as to
+## your rights to use the software. Also, please note that software in 
+## multiverse WILL NOT receive any review or updates from the Ubuntu
+## security team.
+deb http://us-west-2.ec2.archive.ubuntu.com/ubuntu/ trusty multiverse
+deb-src http://us-west-2.ec2.archive.ubuntu.com/ubuntu/ trusty multiverse
+deb http://us-west-2.ec2.archive.ubuntu.com/ubuntu/ trusty-updates multiverse
+deb-src http://us-west-2.ec2.archive.ubuntu.com/ubuntu/ trusty-updates multiverse
+
+## Uncomment the following two lines to add software from the 'backports'
+## repository.
+## N.B. software from this repository may not have been tested as
+## extensively as that contained in the main release, although it includes
+## newer versions of some applications which may provide useful features.
+## Also, please note that software in backports WILL NOT receive any review
+## or updates from the Ubuntu security team.
+deb http://us-west-2.ec2.archive.ubuntu.com/ubuntu/ trusty-backports main restricted universe multiverse
+deb-src http://us-west-2.ec2.archive.ubuntu.com/ubuntu/ trusty-backports main restricted universe multiverse
+
+## Uncomment the following two lines to add software from Canonical's
+## 'partner' repository.
+## This software is not part of Ubuntu, but is offered by Canonical and the
+## respective vendors as a service to Ubuntu users.
+# deb http://archive.canonical.com/ubuntu trusty partner
+# deb-src http://archive.canonical.com/ubuntu trusty partner
+
+deb http://security.ubuntu.com/ubuntu trusty-security main
+deb-src http://security.ubuntu.com/ubuntu trusty-security main
+deb http://security.ubuntu.com/ubuntu trusty-security universe
+deb-src http://security.ubuntu.com/ubuntu trusty-security universe
+# deb http://security.ubuntu.com/ubuntu trusty-security multiverse
+# deb-src http://security.ubuntu.com/ubuntu trusty-security multiverse
+EOF
+sudo apt-get update -y
+
 [ -e /usr/lib/apt/methods/https ] || {
-  apt-get update
   apt-get install apt-transport-https
 }
 
+## upgrade the kernel, along with extra (which adds AUFS support)
+KERNEL_VER=3.19.0-43-generic
+sudo apt-get install -y \
+    linux-image-${KERNEL_VER} \
+    linux-headers-${KERNEL_VER} \
+    linux-image-extra-${KERNEL_VER} \
+    dkms
+
+## Add the docker repo and update to pick it up
 sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 36A1D7869245C8950F966E92D8576A8BA88D21E9
 sudo sh -c "echo deb https://get.docker.io/ubuntu docker main\
 > /etc/apt/sources.list.d/docker.list"
-
-## Update to pick up new registries
 sudo apt-get update -y
 
-## Install all the packages
+## Install all the other packages
 sudo apt-get install -y lxc-docker-1.6.1 btrfs-tools lvm2 curl build-essential \
-  linux-image-extra-`uname -r` git-core pbuilder python-mock python-configobj \
-  python-support cdbs python-pip jq rsyslog-gnutls openvpn v4l2loopback-utils lxc
+  git-core pbuilder python-mock python-configobj \
+  python-support cdbs python-pip jq rsyslog-gnutls openvpn lxc
+
+## Install v4l2loopback; the version avalable from Ubuntu is too old for this kernel
+V4L2LOOPBACK_VER=0.9.1
+cd /usr/src
+rm -rf v4l2loopback-$V4L2LOOPBACK_VER
+sudo git clone --branch v$V4L2LOOPBACK_VER https://github.com/umlaeute/v4l2loopback.git v4l2loopback-$V4L2LOOPBACK_VER
+cd v4l2loopback-$V4L2LOOPBACK_VER
+sudo dkms install -m v4l2loopback -v $V4L2LOOPBACK_VER -k ${KERNEL_VER}
+sudo dkms build -m v4l2loopback -v $V4L2LOOPBACK_VER -k ${KERNEL_VER}
 
 ## Clear mounts created in base image so fstab is empty in other builds...
 sudo sh -c 'echo "" > /etc/fstab'


### PR DESCRIPTION
The new source_ami picks the AMI built on the same data as the HVM source AMI.

I removed `-v` from `set` because it just duplicates every command, which gets pretty confusing.

I'll hold off landing this until I've seen that it makes the `m1.medium` instances not explode, and doesn't break the HVM instances.