### PR TITLE
Bug 1220738: Use temp credentials on task behalf. r=garndt

### DIFF
--- a/bin/worker.js
+++ b/bin/worker.js
@@ -196,9 +196,6 @@ async function main () {
     })
   });
 
-  config.scheduler =
-    new taskcluster.Scheduler({ credentials: config.taskcluster });
-
   config.validator = await base.validator();
   config.validator.register(require('../schemas/payload'));
 

--- a/lib/docker/artifact_image.js
+++ b/lib/docker/artifact_image.js
@@ -25,16 +25,13 @@ export default class ArtifactImage {
    * @param {Object}  stream        - task stream object
    * @param {Array}   taskScopes        - Array of task scopes
    */
-  constructor(runtime, imageDetails, stream, taskScopes=[]) {
+  constructor(runtime, imageDetails, stream, task, taskScopes=[]) {
     this.runtime = runtime;
     this.taskScopes = taskScopes;
     this.stream = stream;
     this.taskId = imageDetails.taskId;
     this.artifactPath = imageDetails.path;
-    this.queue = new taskcluster.Queue({
-      credentials: this.runtime.taskcluster,
-      authorizedScopes: this.taskScopes
-    });
+    this.task = task;
   }
 
   /*
@@ -73,7 +70,7 @@ export default class ArtifactImage {
     try {
       await this.runtime.stats.timeGen('taskImageDownloadTime',
         downloadArtifact(
-          this.queue,
+          this.task.queue,
           this.stream,
           this.taskId,
           this.artifactPath,

--- a/lib/docker/docker_image.js
+++ b/lib/docker/docker_image.js
@@ -19,11 +19,12 @@ const RETRY_CONFIG = {
 };
 
 export default class DockerImage {
-  constructor(runtime, imageDetails, stream, scopes=[]) {
+  constructor(runtime, imageDetails, stream, task, scopes=[]) {
     this.runtime = runtime;
     this.imageName = imageDetails.name;
     this.stream = stream;
     this.scopes = scopes;
+    this.task = task;
 
     var parsed = parseImage(this.imageName);
     this.name = parsed.repository;

--- a/lib/docker/image_manager.js
+++ b/lib/docker/image_manager.js
@@ -52,7 +52,7 @@ export default class ImageManager {
    *                             or will be once image is downloaded.  Ensures
    *                             pulls/downloads are done serially.
    */
-  async ensureImage(imageDetails, stream, scopes = []) {
+  async ensureImage(imageDetails, stream, task, scopes = []) {
     if (typeof imageDetails === 'string') {
       imageDetails = {
         name: imageDetails,
@@ -66,7 +66,7 @@ export default class ImageManager {
          image: imageDetails
         });
 
-        let imageHandler = this.getImageHandler(imageDetails, stream, scopes);
+        let imageHandler = this.getImageHandler(imageDetails, stream, task, scopes);
 
         if (!imageHandler.isAuthorized()) {
           throw new Error(
@@ -92,11 +92,11 @@ export default class ImageManager {
    * @param {Object} stream - Stream object used for piping messages to the task log
    * @param {Array}  scopes - Array of task scopes
    */
-  getImageHandler(image, stream, scopes) {
+  getImageHandler(image, stream, task, scopes) {
     if (!Object.keys(IMAGE_HANDLERS).includes(image.type)) {
       throw new Error(`Unrecognized image type. Image Type: ${image.type}`);
     }
 
-    return new IMAGE_HANDLERS[image.type](this.runtime, image, stream, scopes);
+    return new IMAGE_HANDLERS[image.type](this.runtime, image, stream, task, scopes);
   }
 }

--- a/lib/docker/indexed_image.js
+++ b/lib/docker/indexed_image.js
@@ -15,7 +15,7 @@ export default class IndexedImage extends ArtifactImage {
    * @param {Object}  stream        - task stream object
    * @param {Array}   taskScopes        - Array of task scopes
    */
-  constructor(runtime, imageDetails, stream, taskScopes=[]) {
+  constructor(runtime, imageDetails, stream, task, taskScopes=[]) {
     this.runtime = runtime;
     this.taskScopes = taskScopes;
     this.stream = stream;
@@ -25,10 +25,7 @@ export default class IndexedImage extends ArtifactImage {
       credentials: this.runtime.taskcluster,
       authorizedScopes: this.taskScopes
     });
-    this.queue = new taskcluster.Queue({
-      credentials: this.runtime.taskcluster,
-      authorizedScopes: this.taskScopes
-    });
+    this.task = task;
   }
 
   /* Downloads an image that is indexed at the given namespace and path.

--- a/lib/features/artifacts.js
+++ b/lib/features/artifacts.js
@@ -24,7 +24,7 @@ export default class Artifacts {
   async uploadArtifact(taskHandler, name, artifact) {
     let errors = [];
     let container = taskHandler.dockerProcess.container;
-    let queue = taskHandler.runtime.queue;
+    let queue = taskHandler.queue;
     let path = artifact.path;
     let expiry;
 
@@ -139,7 +139,7 @@ export default class Artifacts {
       };
 
       try {
-        await uploadToS3(taskHandler.runtime.queue, taskId, runId, stream,
+        await uploadToS3(taskHandler.queue, taskId, runId, stream,
                          entryName, expiry, headers);
       } catch(err) {
         debug(err);

--- a/lib/features/azure_live_log.js
+++ b/lib/features/azure_live_log.js
@@ -49,7 +49,7 @@ export default class LiveLog {
   constructor () {}
 
   async created(task) {
-    var queue = task.runtime.queue;
+    var queue = task.queue;
 
     // Create date when this artifact should expire (see config).
     var expiration = new Date(

--- a/lib/features/balrog_vpn_proxy.js
+++ b/lib/features/balrog_vpn_proxy.js
@@ -60,7 +60,7 @@ export default class BalrogVPNProxy {
     let imageScopes = [`${IMAGE_SCOPE_PREFIX+image}`];
 
     debug('ensuring image');
-    let imageId = await task.runtime.imageManager.ensureImage(image, process.stdout, imageScopes);
+    let imageId = await task.runtime.imageManager.ensureImage(image, process.stdout, task, imageScopes);
     debug('image verified %s', imageId);
 
     // create the container.

--- a/lib/features/bulk_log.js
+++ b/lib/features/bulk_log.js
@@ -47,7 +47,7 @@ export default class BulkLog {
     expiration = new Date(Math.min(expiration, new Date(task.task.expires)));
 
     try {
-      await uploadToS3(task.runtime.queue, task.status.taskId, task.runId,
+      await uploadToS3(task.queue, task.status.taskId, task.runId,
                        diskStream, this.artifactName, expiration, {
         'content-type': 'text/plain',
         'content-length': stat.size,
@@ -62,7 +62,7 @@ export default class BulkLog {
     // Unlink the temp file.
     await fs.unlink(this.file.path);
 
-    var queue = task.runtime.queue;
+    var queue = task.queue;
 
     return queue.buildUrl(
       queue.getArtifact,

--- a/lib/features/dind.js
+++ b/lib/features/dind.js
@@ -32,7 +32,7 @@ export default class DockerInDocker {
     debug('ensuring image');
     let imageManager = task.runtime.imageManager;
     let image = task.runtime.dindImage;
-    let imageId = await imageManager.ensureImage(image, process.stdout);
+    let imageId = await imageManager.ensureImage(image, process.stdout, task);
     debug('image verified %s', imageId);
 
     // Create temporary directory

--- a/lib/features/docker_save.js
+++ b/lib/features/docker_save.js
@@ -43,7 +43,7 @@ export default class DockerSave {
     let expiration = taskcluster.fromNow(task.runtime.dockerSave.expiration);
     expiration = new Date(Math.min(expiration, new Date(task.task.expires)));
 
-    await uploadToS3(task.runtime.queue, task.status.taskId, task.runId,
+    await uploadToS3(task.queue, task.status.taskId, task.runId,
       uploadStream, 'public/dockerImage.tar', expiration, {
       'content-type': 'application/x-tar',
       'content-length': stat.size,
@@ -76,7 +76,7 @@ export default class DockerSave {
     expiration = new Date(Math.min(expiration, new Date(task.task.expires)));
     let stat = await fs.stat(pathname);
 
-    await uploadToS3(task.runtime.queue, task.status.taskId, task.runId,
+    await uploadToS3(task.queue, task.status.taskId, task.runId,
       fs.createReadStream(pathname),
       'public/cache/' + cache.cacheName + '.tar',
       expiration, {

--- a/lib/features/extend_task_graph.js
+++ b/lib/features/extend_task_graph.js
@@ -5,6 +5,7 @@ var debug = require('debug')('docker-worker:middleware:extendTaskGraph');
 var waitForEvent = require('../wait_for_event');
 var tarStream = require('tar-stream');
 var log = require('../log');
+var taskcluster = require('taskcluster-client');
 
 
 async function drain (listener) {
@@ -28,7 +29,9 @@ export default class ExtendTaskGraph {
     var graphId = task.taskGroupId;
 
     var container = taskHandler.dockerProcess.container;
-    var scheduler = taskHandler.runtime.scheduler;
+    var scheduler = new taskcluster.Scheduler({
+      credentials: taskHandler.claim.credentials
+    });
 
     // Raw tar stream for the content.
     var contentStream;
@@ -84,7 +87,6 @@ export default class ExtendTaskGraph {
         'Dumping file. ' + JSON.stringify(entryJSON, null, 2)
       );
     }
-
     // Extend the graph!
     try {
       var result = await scheduler.extendTaskGraph(graphId, extension);

--- a/lib/features/interactive.js
+++ b/lib/features/interactive.js
@@ -328,7 +328,7 @@ export default class WebsocketServer {
     let expiration = new Date(
       Math.min(Date.now() + task.task.payload.maxRunTime,
       new Date(task.task.expires)));
-    let queue = task.runtime.queue;
+    let queue = task.queue;
 
     let toolsShellArtifact = queue.createArtifact(
       task.status.taskId,

--- a/lib/features/local_live_log.js
+++ b/lib/features/local_live_log.js
@@ -142,7 +142,7 @@ export default class TaskclusterLogs {
     debug('live log running: putUrl', putUrl)
     debug('live log running: publicUrl', this.publicUrl);
 
-    let queue = task.runtime.queue;
+    let queue = task.queue;
 
     // Intentionally used the same expiration as the bulkLog
     let expiration = new Date(
@@ -198,7 +198,7 @@ export default class TaskclusterLogs {
       Math.min(Date.now() + task.runtime.logging.bulkLogExpires,
       new Date(task.task.expires)));
 
-    await task.runtime.queue.createArtifact(
+    await task.queue.createArtifact(
       task.status.taskId,
       task.runId,
       this.logsLocations.live,

--- a/lib/features/local_live_log.js
+++ b/lib/features/local_live_log.js
@@ -48,7 +48,7 @@ export default class TaskclusterLogs {
     // Image name for the proxy container.
     let image = task.runtime.taskclusterLogImage;
     debug('ensuring image');
-    let imageId = await task.runtime.imageManager.ensureImage(image, process.stdout);
+    let imageId = await task.runtime.imageManager.ensureImage(image, process.stdout, task);
     debug('image verified %s', imageId);
 
     let envs = [];

--- a/lib/features/releng_api_proxy.js
+++ b/lib/features/releng_api_proxy.js
@@ -27,7 +27,7 @@ export default class RelengAPIProxy {
 
     // Image name for the proxy container.
     var image = task.runtime.features.relengAPIProxy.image;
-    var imageId = await task.runtime.imageManager.ensureImage(image, process.stdout);
+    var imageId = await task.runtime.imageManager.ensureImage(image, process.stdout, task);
 
     var cmd = [
         `--relengapi-token=${task.runtime.features.relengAPIProxy.token}`,

--- a/lib/features/taskcluster_proxy.js
+++ b/lib/features/taskcluster_proxy.js
@@ -4,6 +4,7 @@ allows tasks to talk directly to taskcluster services over a http proxy which
 grants a particular permission level based on the task scopes.
 */
 import waitForPort from '../wait_for_port';
+import http from 'http';
 
 // Alias used to link the proxy.
 const ALIAS = 'taskcluster';
@@ -28,21 +29,17 @@ export default class TaskclusterProxy {
     var image = task.runtime.taskclusterProxyImage;
     var imageId = await task.runtime.imageManager.ensureImage(image, process.stdout);
 
-    var assumedScope = 'assume:worker-id:' + task.runtime.workerGroup +
-                       '/' + task.runtime.workerId;
-
     var cmd = [
-        '--client-id=' + task.runtime.taskcluster.clientId,
-        '--access-token=' + task.runtime.taskcluster.accessToken
+        '--client-id=' + task.claim.credentials.clientId,
+        '--access-token=' + task.claim.credentials.accessToken
     ];
     // only pass in a certificate if one has been set
-    if (task.runtime.taskcluster.certificate) {
-        cmd.push('--certificate=' + task.runtime.taskcluster.certificate);
+    if (task.claim.credentials.certificate) {
+        cmd.push('--certificate=' + task.claim.credentials.certificate);
     }
-    cmd.push(
-        task.status.taskId,
-        assumedScope
-    );
+    const cert = JSON.parse(task.claim.credentials.certificate);
+    cmd.push(task.status.taskId);
+    cmd = cmd.concat(cert.scopes);
 
     // create the container.
     this.container = await docker.createContainer({
@@ -83,6 +80,42 @@ export default class TaskclusterProxy {
     } catch (e) {
       throw new Error('Failed to initialize taskcluster proxy service.');
     }
+
+    // Update credentials in proxy
+    task.on('credentials', async (credentials) => {
+      let credentials = JSON.stringify(task.claim.credentials);
+
+      await new Promise((accept, reject) => {
+        let req = http.request({
+          hostname: inspect.NetworkSettings.IPAddress,
+          method: 'PUT',
+          path: '/credentials',
+          headers: {
+            'Content-Type': 'text/json',
+            'Content-Length': credentials.length
+          }
+        }, res => {
+          if (res.statusCode == 200) {
+            task.runtime.log('Credentials updated', {
+              taskId: task.status.taskId,
+              runId: task.runId
+            });
+            accept();
+          } else {
+            let err = new Error(`Credentials update failed ${res.statusCode}`);
+            task.runtime.log(err, {
+              taskId: task.status.taskId,
+              runId: task.runId
+            });
+            reject(err);
+          }
+        });
+
+        req.on('error', err => reject(err));
+        req.write(credentials);
+        req.end();
+      });
+    });
 
     return {
       links: [{name, alias: ALIAS}],

--- a/lib/features/taskcluster_proxy.js
+++ b/lib/features/taskcluster_proxy.js
@@ -27,7 +27,7 @@ export default class TaskclusterProxy {
 
     // Image name for the proxy container.
     var image = task.runtime.taskclusterProxyImage;
-    var imageId = await task.runtime.imageManager.ensureImage(image, process.stdout);
+    var imageId = await task.runtime.imageManager.ensureImage(image, process.stdout, task);
 
     var cmd = [
         '--client-id=' + task.claim.credentials.clientId,

--- a/lib/features/testdroid_proxy.js
+++ b/lib/features/testdroid_proxy.js
@@ -39,7 +39,7 @@ export default class TestdroidProxy {
     let image = task.runtime.testdroidProxyImage;
 
     debug('ensuring image');
-    let imageId = await task.runtime.imageManager.ensureImage(image, process.stdout);
+    let imageId = await task.runtime.imageManager.ensureImage(image, process.stdout, task);
     debug('image verified %s', imageId);
 
     let cmd = [

--- a/lib/task.js
+++ b/lib/task.js
@@ -836,6 +836,7 @@ export class Task extends EventEmitter {
       let im = this.runtime.imageManager;
       imageId = await im.ensureImage(this.task.payload.image,
                                      this.stream,
+                                     this,
                                      this.task.scopes);
       this.runtime.gc.markImage(imageId);
     } catch (e) {

--- a/lib/task.js
+++ b/lib/task.js
@@ -11,6 +11,8 @@ import { PassThrough } from 'stream';
 import States from './states';
 import fs from "mz/fs";
 import child_process from "mz/child_process";
+import taskcluster from 'taskcluster-client';
+import base from 'taskcluster-base';
 
 import features from './features';
 import getHostname from './util/hostname';
@@ -222,8 +224,9 @@ export class Reclaimer {
     this.log('reclaiming task');
 
     try {
-      this.claim = await this.runtime.queue.reclaimTask(
-                                this.claim.status.taskId, this.claim.runId);
+      let queue = this.task.createQueue(this.claim.credentials, this.runtime);
+      this.claim = await queue.reclaimTask(
+                    this.claim.status.taskId, this.claim.runId);
       // reclaim does not return the task, so carry that forward from the previous
       // claim
       this.claim.task = task;
@@ -249,6 +252,10 @@ export class Reclaimer {
       }
 
       return;
+    }
+
+    if (this.claim.status.taskId == this.primaryClaim.status.taskId) {
+      this.task.queue = this.task.createQueue(this.claim.credentials, this.runtime);
     }
 
     this.log('reclaimed task');
@@ -283,6 +290,8 @@ export class Task {
     this.runId = this.claim.runId;
     this.taskState = 'pending';
     this.options = options;
+
+    this.queue = this.createQueue(this.claim.credentials, runtime);
 
     // Primarly log of all actions for the task.
     this.stream = new PassThrough();
@@ -517,7 +526,7 @@ export class Task {
     }
 
     if (this.isAborted()) {
-      let queue = this.runtime.queue;
+      let queue = this.queue;
       let reporter = this.taskException ? queue.reportException : queue.reportFailed;
       let reportDetails = [this.status.taskId, this.runId];
       if (this.taskException) reportDetails.push({ reason: this.taskException });
@@ -549,7 +558,7 @@ export class Task {
    * @param {Boolean} success
    */
   async completeRun(success) {
-    let queue = this.runtime.queue;
+    let queue = this.queue;
     let reporter = success ? queue.reportCompleted : queue.reportFailed;
     let reportDetails = [this.status.taskId, this.runId];
 
@@ -578,7 +587,7 @@ export class Task {
    */
 
   async resolveSuperseded(primaryTaskId, primaryRunId, addArtifacts, reason) {
-    let queue = this.runtime.queue;
+    let queue = this.queue;
     let supersedes = [];
     let log = this.runtime.log;
 
@@ -967,5 +976,30 @@ export class Task {
       return await this.abortRun(this.taskState);
     }
     return success;
+  }
+
+  /**
+  Create a new queue using temp credentials.
+
+  @param {credentials} Temporary credentials.
+  @param {runtime} Runtime config.
+
+  @return New queue.
+  */
+  createQueue(credentials, runtime) {
+    return new taskcluster.Queue({
+      credentials: credentials,
+      stats: base.stats.createAPIClientStatsHandler({
+        drain: runtime.stats.influx,
+        tags: {
+          component: 'docker-worker',
+          workerId: runtime.workerId,
+          workerGroup: runtime.workerGroup,
+          workerType: runtime.workerType,
+          instanceType: runtime.workerNodeType,
+          provisionerId: runtime.provisionerId
+        }
+      })
+    });
   }
 }

--- a/lib/task.js
+++ b/lib/task.js
@@ -24,6 +24,7 @@ import { validatePayload } from './util/validate_schema';
 import waitForEvent from './wait_for_event';
 import uploadToS3 from './upload_to_s3';
 import _ from 'lodash';
+import EventEmitter from 'events';
 
 let debug = new Debug('runTask');
 
@@ -256,6 +257,7 @@ export class Reclaimer {
 
     if (this.claim.status.taskId == this.primaryClaim.status.taskId) {
       this.task.queue = this.task.createQueue(this.claim.credentials, this.runtime);
+      this.task.emit('credentials', this.claim.credentials);
     }
 
     this.log('reclaimed task');
@@ -273,7 +275,7 @@ export class Reclaimer {
   }
 }
 
-export class Task {
+export class Task extends EventEmitter {
   /**
   @param {Object} runtime global runtime.
   @param {Object} task for this instance.

--- a/test/image_manager_test.js
+++ b/test/image_manager_test.js
@@ -7,6 +7,7 @@ import {createHash} from 'crypto';
 import slugid from 'slugid';
 import {createLogger} from '../lib/log';
 import {NAMESPACE, TASK_ID} from './fixtures/image_artifacts';
+import taskcluster from 'taskcluster-client';
 
 let docker = Docker();
 
@@ -65,9 +66,16 @@ suite('Image Manager', () => {
       }
     };
 
+    let task = {
+      queue: new taskcluster.Queue({
+        credentials: undefined,
+        scopes: [],
+      }),
+    };
+
     let im = new ImageManager(runtime);
-    let imageId1 = await im.ensureImage(image, process.stdout, []);
-    let imageId2 = await im.ensureImage(image, process.stdout);
+    let imageId1 = await im.ensureImage(image, process.stdout, task, []);
+    let imageId2 = await im.ensureImage(image, process.stdout, task);
 
     assert.ok(imageId1, 'No image id was returned');
     assert.equal(imageId1, imageId2, 'Image IDs for the same image should be the same');
@@ -98,8 +106,15 @@ suite('Image Manager', () => {
       }
     };
 
+    let task = {
+      queue: new taskcluster.Queue({
+        credentials: undefined,
+        scopes: [],
+      }),
+    };
+
     let im = new ImageManager(runtime);
-    let imageId = await im.ensureImage(image, process.stdout, []);
+    let imageId = await im.ensureImage(image, process.stdout, task, []);
 
     assert.ok(imageId, 'No image id was returned');
   });
@@ -129,9 +144,16 @@ suite('Image Manager', () => {
       }
     };
 
+    let task = {
+      queue: new taskcluster.Queue({
+        credentials: undefined,
+        scopes: [],
+      }),
+    };
+
     let im = new ImageManager(runtime);
     try {
-      await im.ensureImage(image, process.stdout, []);
+      await im.ensureImage(image, process.stdout, task, []);
       assert.ok(false, 'Images should not be used when proper scopes are not provided');
     } catch(e) {
       return;
@@ -165,8 +187,15 @@ suite('Image Manager', () => {
       }
     };
 
+    let task = {
+      queue: new taskcluster.Queue({
+        credentials: undefined,
+        scopes: [],
+      }),
+    };
+
     let im = new ImageManager(runtime);
-    let imageId = await im.ensureImage(image, process.stdout, scopes);
+    let imageId = await im.ensureImage(image, process.stdout, task, scopes);
 
     assert.ok(imageId, 'Image should have been loaded');
   });
@@ -195,8 +224,15 @@ suite('Image Manager', () => {
       }
     };
 
+    let task = {
+      queue: new taskcluster.Queue({
+        credentials: undefined,
+        scopes: [],
+      }),
+    };
+
     let im = new ImageManager(runtime);
-    let imageId = await im.ensureImage(image, process.stdout, []);
+    let imageId = await im.ensureImage(image, process.stdout, task, []);
 
     assert.ok(imageId, 'No image id was returned');
   });
@@ -218,9 +254,16 @@ suite('Image Manager', () => {
       }
     };
 
+    let task = {
+      queue: new taskcluster.Queue({
+        credentials: undefined,
+        scopes: [],
+      }),
+    };
+
     let im = new ImageManager(runtime);
     try {
-      let imageId = await im.ensureImage(image, process.stdout, []);
+      let imageId = await im.ensureImage(image, process.stdout, task, []);
       assert.ok(false, 'Exception should have been thrown');
     } catch(e) {
       assert.ok(
@@ -247,9 +290,16 @@ suite('Image Manager', () => {
       }
     };
 
+    let task = {
+      queue: new taskcluster.Queue({
+        credentials: undefined,
+        scopes: [],
+      }),
+    };
+
     let im = new ImageManager(runtime);
     try {
-      let imageId = await im.ensureImage(image, process.stdout, []);
+      let imageId = await im.ensureImage(image, process.stdout, task, []);
       assert.ok(false, 'Exception should have been thrown');
     } catch(e) {
       assert.ok(
@@ -275,9 +325,16 @@ suite('Image Manager', () => {
       }
     };
 
+    let task = {
+      queue: new taskcluster.Queue({
+        credentials: undefined,
+        scopes: [],
+      }),
+    };
+
     let im = new ImageManager(runtime);
     try {
-      await im.ensureImage(image, process.stdout, []);
+      await im.ensureImage(image, process.stdout, task, []);
       assert.ok(false, 'Exception should have been thrown');
     } catch(e) {
       assert.ok(

--- a/test/integration/taskgraph_extension_test.js
+++ b/test/integration/taskgraph_extension_test.js
@@ -38,6 +38,9 @@ suite('Extend Task Graph', function() {
         source: 'http://mytest/',
         owner: 'test@localhost.local'
       },
+      scopes: [
+        'scheduler:extend-task-graph:' + graphId
+      ],
       payload: {
         image: 'taskcluster/test-ubuntu',
         command: cmd('echo "wooot custom!"'),
@@ -63,7 +66,8 @@ suite('Extend Task Graph', function() {
         source: 'http://xfoobar.com'
       },
       scopes: [
-        'queue:define-task:' + worker.provisionerId + '/' + worker.workerType
+        'queue:define-task:' + worker.provisionerId + '/' + worker.workerType,
+        'scheduler:extend-task-graph:' + graphId
       ],
       tasks: [{
         taskId: primaryTaskId,
@@ -72,6 +76,10 @@ suite('Extend Task Graph', function() {
           metadata: {
             owner: 'tests@local.localhost'
           },
+          scopes: [
+            'queue:define-task:' + worker.provisionerId + '/' + worker.workerType,
+            'scheduler:extend-task-graph:' + graphId
+          ],
           payload: {
             image: 'taskcluster/test-ubuntu',
             command: cmd(
@@ -119,7 +127,8 @@ suite('Extend Task Graph', function() {
         source: 'http://xfoobar.com'
       },
       scopes: [
-        'queue:define-task:' + worker.provisionerId + '/' + worker.workerType
+        'queue:define-task:' + worker.provisionerId + '/' + worker.workerType,
+        'scheduler:extend-task-graph:' + graphId
       ],
       tasks: [{
         taskId: primaryTaskId,
@@ -128,6 +137,10 @@ suite('Extend Task Graph', function() {
           metadata: {
             owner: 'tests@local.localhost'
           },
+          scopes: [
+            'queue:define-task:' + worker.provisionerId + '/' + worker.workerType,
+            'scheduler:extend-task-graph:' + graphId
+          ],
           payload: {
             image: 'taskcluster/test-ubuntu',
             command: cmd(
@@ -197,7 +210,8 @@ suite('Extend Task Graph', function() {
         source: 'http://xfoobar.com'
       },
       scopes: [
-        'queue:define-task:' + worker.provisionerId + '/' + worker.workerType
+        'queue:define-task:' + worker.provisionerId + '/' + worker.workerType,
+        'scheduler:extend-task-graph:' + graphId
       ],
       tasks: [{
         taskId: primaryTaskId,
@@ -206,6 +220,10 @@ suite('Extend Task Graph', function() {
           metadata: {
             owner: 'tests@local.localhost'
           },
+          scopes: [
+            'queue:define-task:' + worker.provisionerId + '/' + worker.workerType,
+            'scheduler:extend-task-graph:' + graphId
+          ],
           payload: {
             image: 'taskcluster/test-ubuntu',
             command: cmd(
@@ -241,7 +259,11 @@ suite('Extend Task Graph', function() {
       provisionerId: worker.provisionerId,
       // Because this scope is not included in the scopes the graph has, extending
       // the task graph will fail
-      scopes: ['this-is-a-bad-scope'],
+      scopes: [
+        'this-is-a-bad-scope',
+        'queue:define-task:' + worker.provisionerId + '/' + worker.workerType,
+        'scheduler:extend-task-graph:' + graphId
+      ],
       metadata: {
         description: 'testing',
         source: 'http://mytest/',
@@ -272,7 +294,8 @@ suite('Extend Task Graph', function() {
         source: 'http://xfoobar.com'
       },
       scopes: [
-        'queue:define-task:' + worker.provisionerId + '/' + worker.workerType
+        'queue:define-task:' + worker.provisionerId + '/' + worker.workerType,
+        'scheduler:extend-task-graph:' + graphId
       ],
       tasks: [{
         taskId: primaryTaskId,
@@ -281,6 +304,10 @@ suite('Extend Task Graph', function() {
           metadata: {
             owner: 'tests@local.localhost'
           },
+          scopes: [
+            'queue:define-task:' + worker.provisionerId + '/' + worker.workerType,
+            'scheduler:extend-task-graph:' + graphId
+          ],
           payload: {
             image: 'taskcluster/test-ubuntu',
             command: cmd(


### PR DESCRIPTION
For all task related queue operations, we use a queue object created
with temporary credentials.