### PR TITLE
Apply security updates on boot

### DIFF
--- a/deploy/packer/app.json
+++ b/deploy/packer/app.json
@@ -4,8 +4,8 @@
   "variables": {
     "npmPackage":          "",
     "templateContents":    "",
-    "hvmSourceAMI":        "ami-b63822d7",
-    "pvSourceAMI":         "ami-ed051f8c",
+    "hvmSourceAMI":        "ami-9d00e3fd",
+    "pvSourceAMI":         "ami-460ae926",
     "fsType":              "",
     "workerRevision":      ""
   },
@@ -34,6 +34,10 @@
       "inline": [
         "/tmp/deploy.sh /tmp/deploy.tar.gz /tmp/docker-worker.tgz"
       ]
+    },
+    {
+      "type":           "shell",
+      "inline":         ["sudo unattended-upgrade"]
     }
   ],
   "builders": [

--- a/deploy/packer/base.json
+++ b/deploy/packer/base.json
@@ -40,6 +40,10 @@
         "deploy/packer/base/scripts/node.sh",
         "deploy/packer/base/scripts/diamond.sh"
       ]
+    },
+    {
+      "type":           "shell",
+      "inline":         ["sudo unattended-upgrade"]
     }
   ],
   "builders": [

--- a/deploy/packer/base/scripts/packages.sh
+++ b/deploy/packer/base/scripts/packages.sh
@@ -22,9 +22,26 @@ sudo sh -c "echo deb https://get.docker.io/ubuntu docker main\
 sudo apt-get update -y
 
 ## Install all the packages
-sudo apt-get install -y lxc-docker-1.6.1 btrfs-tools lvm2 curl build-essential \
-  linux-image-extra-`uname -r` git-core pbuilder python-mock python-configobj \
-  python-support cdbs python-pip jq rsyslog-gnutls openvpn v4l2loopback-utils lxc
+sudo apt-get install -y \
+    unattended-upgrades \
+    lxc-docker-1.6.1 \
+    btrfs-tools \
+    lvm2 \
+    curl \
+    build-essential \
+    linux-image-extra-`uname -r` \
+    git-core \
+    pbuilder \
+    python-mock \
+    python-configobj \
+    python-support \
+    cdbs \
+    python-pip \
+    jq \
+    rsyslog-gnutls \
+    openvpn \
+    v4l2loopback-utils \
+    lxc
 
 ## Clear mounts created in base image so fstab is empty in other builds...
 sudo sh -c 'echo "" > /etc/fstab'

--- a/deploy/template/etc/cloud/cloud.cfg
+++ b/deploy/template/etc/cloud/cloud.cfg
@@ -14,6 +14,11 @@ disable_root: true
 # This will cause the set+update hostname module to not operate (if true)
 preserve_hostname: false
 
+# Apply security updates on boot
+runcmd:
+ - [ sh, -c, echo "=========Applying Security Updates=========" ]
+ - [ sudo, unattended-upgrade ]
+
 # Example datasource config
 # datasource:
 #    Ec2:


### PR DESCRIPTION
This should run the unattended upgrade procedure during the cloud init phase.

Tested it out with an ami that was create with this and without.  glibc appears to be updated on the one with these statements 

before:
ubuntu@ip-172-31-40-141:~$ ldd --version
ldd (Ubuntu EGLIBC 2.19-0ubuntu6.6) 2.19

after:
ubuntu@ip-172-31-23-40:~$ ldd --version
ldd (Ubuntu EGLIBC 2.19-0ubuntu6.7) 2.19