### PR TITLE
Bug 1250316 - Compare downloaded file size for indexed image downloads

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -15,6 +15,4 @@ Vagrant.configure("2") do |config|
 SCRIPT
 
   config.vm.provision "shell", path: 'vagrant.sh'
-  config.vm.provision "docker", images: [], version: "1.6.1"
-
 end

--- a/lib/util/remove_image.js
+++ b/lib/util/remove_image.js
@@ -1,0 +1,12 @@
+export async function removeImage(docker, image) {
+  let dockerImage = docker.getImage(image);
+  try {
+    await dockerImage.remove({force: true});
+  } catch(e) {
+    if (e.reason === 'no such image') {
+      return;
+    }
+
+    throw e;
+  }
+}

--- a/test/garbage_collection_test.js
+++ b/test/garbage_collection_test.js
@@ -12,6 +12,7 @@ suite('garbage collection tests', function () {
   var waitForEvent = require('../lib/wait_for_event');
   var path = require('path');
   var rmrf = require('rimraf');
+  var removeImage = require('../lib/util/remove_image').removeImage;
 
   var IMAGE = 'taskcluster/test-ubuntu';
 
@@ -342,7 +343,7 @@ suite('garbage collection tests', function () {
     gc.markImage(imageId);
 
     var image = docker.getImage(imageId);
-    yield image.remove();
+    yield removeImage(docker, imageId);
 
     gc.sweep();
 

--- a/test/integration/docker_save_test.js
+++ b/test/integration/docker_save_test.js
@@ -11,6 +11,7 @@ import tar from 'tar-fs';
 import TestWorker from '../testworker';
 import waitForEvent from '../../lib/wait_for_event';
 import Debug from 'debug';
+import {removeImage} from '../../lib/util/remove_image';
 
 let debug = Debug('docker-worker:test:docker-save-test');
 
@@ -86,7 +87,7 @@ suite('use docker-save', () => {
     });
     await base.testing.sleep(100);
     await Promise.all([container.remove(), fs.unlink('/tmp/dockerload.tar')]);
-    await docker.getImage(imageName).remove();
+    await removeImage(docker, imageName);
   });
 
   test('run cacheSave, then check contents', async () => {

--- a/test/integration/helper/docker_registry.js
+++ b/test/integration/helper/docker_registry.js
@@ -5,6 +5,7 @@ import slugid from 'slugid';
 
 import waitForEvent from '../../../lib/wait_for_event';
 import sleep from '../../../lib/util/sleep';
+import {removeImage} from '../../../lib/util/remove_image';
 
 // Registry proxy image...
 const DOCKER_IMAGE = 'registry:2';
@@ -138,8 +139,8 @@ export default class Registry {
     // yet.  This is a safeguard (read: hack)
     await sleep(20000);
 
-    await newImage.remove();
-    await image.remove();
+    await removeImage(docker, newImageName);
+    await removeImage(docker, imageName);
 
     return newImageName + ':' + tag;
   }

--- a/test/integration/pull_image_test.js
+++ b/test/integration/pull_image_test.js
@@ -1,20 +1,21 @@
-suite('pull image', function() {
-  var assert = require('assert');
-  var co = require('co');
-  var testworker = require('../post_task');
-  var docker = require('../../lib/docker')();
-  var dockerUtils = require('dockerode-process/utils');
-  var cmd = require('./helper/cmd');
-  var slugid = require('slugid');
-  var expires = require('./helper/expires');
-  var NAMESPACE = require('../fixtures/image_artifacts').NAMESPACE;
-  var TASK_ID = require('../fixtures/image_artifacts').TASK_ID;
-  var createHash = require('crypto').createHash;
+import assert from 'assert';
+import testworker from '../post_task';
+import Docker from '../../lib/docker';
+import cmd from './helper/cmd';
+import {NAMESPACE} from '../fixtures/image_artifacts';
+import {TASK_ID} from '../fixtures/image_artifacts';
+import {createHash} from 'crypto';
+import {removeImage} from '../../lib/util/remove_image';
 
-  test('ensure docker image can be pulled', co(function* () {
+let docker = Docker();
+
+suite('pull image', () => {
+
+  test('ensure docker image can be pulled', async () => {
     let image = 'gliderlabs/alpine:latest';
-    yield dockerUtils.removeImageIfExists(docker, image);
-    var result = yield testworker({
+    await removeImage(docker, image);
+
+    let result = await testworker({
       payload: {
         image: image,
         command: cmd('ls'),
@@ -24,7 +25,7 @@ suite('pull image', function() {
 
     assert.equal(result.run.state, 'completed', 'task should be successful');
     assert.equal(result.run.reasonResolved, 'completed', 'task should be successful');
-  }));
+  });
 
   test('ensure public image from a task can be pulled', async () => {
     let image = {
@@ -37,8 +38,7 @@ suite('pull image', function() {
                       .update(`${TASK_ID}${image.path}`)
                       .digest('hex');
 
-    await dockerUtils.removeImageIfExists(docker, hashedName);
-
+    await removeImage(docker, hashedName);
 
     let result = await testworker({
       payload: {
@@ -65,7 +65,7 @@ suite('pull image', function() {
                       .update(`${TASK_ID}${image.path}`)
                       .digest('hex');
 
-    await dockerUtils.removeImageIfExists(docker, hashedName);
+    await removeImage(docker, hashedName);
 
     let result = await testworker({
       payload: {
@@ -91,7 +91,7 @@ suite('pull image', function() {
                       .update(`${TASK_ID}${image.path}`)
                       .digest('hex');
 
-    await dockerUtils.removeImageIfExists(docker, hashedName);
+    await removeImage(docker, hashedName);
 
     let result = await testworker({
       scopes: ['queue:get-artifact:private/docker-worker-tests/image.tar'],
@@ -118,7 +118,7 @@ suite('pull image', function() {
                       .update(`${TASK_ID}${image.path}`)
                       .digest('hex');
 
-    await dockerUtils.removeImageIfExists(docker, hashedName);
+    await removeImage(docker, hashedName);
 
     let result = await testworker({
       payload: {
@@ -133,8 +133,8 @@ suite('pull image', function() {
     assert.equal(result.run.reasonResolved, 'failed', 'task should have failed');
   });
 
-  test('Task marked as failed if non-existent image is specified', co(function* () {
-    var result = yield testworker({
+  test('Task marked as failed if non-existent image is specified', async () => {
+    var result = await testworker({
       payload: {
         image: 'ubuntu:99.99',
         command: cmd('ls'),
@@ -143,6 +143,6 @@ suite('pull image', function() {
     });
     assert.equal(result.run.state, 'failed', 'task should be successful');
     assert.equal(result.run.reasonResolved, 'failed', 'task should be successful');
-  }));
+  });
 });
 

--- a/test/integration/registry_auth_test.js
+++ b/test/integration/registry_auth_test.js
@@ -7,6 +7,7 @@ import DockerWorker from '../dockerworker';
 import Registry from './helper/docker_registry';
 import * as settings from '../settings';
 import TestWorker from '../testworker';
+import {removeImage} from '../../lib/util/remove_image';
 
 const CREDENTIALS = {
   username: 'testuser',
@@ -44,8 +45,7 @@ suite('Docker custom private registry', () => {
     await worker.terminate();
     settings.cleanup();
     try {
-      let image = await docker.getImage(registryImageName);
-      await image.remove({force: true});
+      await removeImage(docker, registryImageName);
     } catch(e) {
       // 404's are ok if the test failed to pull the image
       if (e.statusCode !== 404) {

--- a/vagrant.sh
+++ b/vagrant.sh
@@ -2,18 +2,29 @@
 
 sudo ln -s /vagrant /worker
 
+NODE_VERSION=v0.12.4
+DOCKER_VERSION=1.6.1
+
 # Install node
-export NODE_VERSION=v0.12.4
 cd /usr/local/ && \
   curl https://nodejs.org/dist/$NODE_VERSION/node-$NODE_VERSION-linux-x64.tar.gz | tar -xz --strip-components 1 && \
   node -v
 
+sudo apt-get install apt-transport-https
 
-sudo apt-get update
-sudo apt-get install -y lxc build-essential jq
+sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 36A1D7869245C8950F966E92D8576A8BA88D21E9
+sudo sh -c "echo deb https://get.docker.io/ubuntu docker main\
+> /etc/apt/sources.list.d/docker.list"
 
-# Install nice-to-haves
-sudo apt-get install -y jq
+sudo apt-get update -y
+sudo apt-get install -y \
+    lxc \
+    lxc-docker-$DOCKER_VERSION \
+    build-essential \
+    jq
+
+# Add vagrant user to the docker group
+sudo usermod -a -G docker vagrant
 
 # Install Video loopback devices
 sudo apt-get install -y \


### PR DESCRIPTION
There are times where the download will be ended but the entire artifact was now downloaded.  When this happens, the sizes should be compared, and an exception thrown if they do not match.