### PR TITLE
Update base image to have unexpired cert

### DIFF
--- a/deploy/packer/app.json
+++ b/deploy/packer/app.json
@@ -4,8 +4,8 @@
   "variables": {
     "npmPackage":          "",
     "templateContents":    "",
-    "hvmSourceAMI":        "ami-130cee73",
-    "pvSourceAMI":         "ami-1e0def7e",
+    "hvmSourceAMI":        "ami-ccc52cac",
+    "pvSourceAMI":         "ami-5ec52c3e",
     "fsType":              "",
     "workerRevision":      ""
   },


### PR DESCRIPTION
This updates the certificate used for live logging and secure websockets which expired on 2016/03/16