### PR TITLE
Add timings for image download and loading

### DIFF
--- a/lib/docker/docker_image.js
+++ b/lib/docker/docker_image.js
@@ -2,9 +2,7 @@ import Debug from 'debug';
 import dockerUtils from 'dockerode-process/utils';
 import parseImage from 'docker-image-parser';
 import { scopeMatch } from 'taskcluster-base/utils';
-
 import sleep from '../util/sleep';
-import waitForEvent from '../wait_for_event';
 
 let debug = Debug('docker-worker:dockerImage');
 
@@ -87,10 +85,13 @@ export default class DockerImage {
       pullOptions.authconfig = this.credentials;
     }
 
-    return await this.pullImageStreamTo(this.runtime.docker,
-                                        dockerImageName,
-                                        this.stream,
-                                        pullOptions);
+    return await this.runtime.stats.timeGen(
+        'dockerImageDownloadTime',
+        this.pullImageStreamTo(this.runtime.docker,
+                               dockerImageName,
+                               this.stream,
+                               pullOptions)
+    );
   }
 
   async pullImageStreamTo(docker, image, stream, options={}) {

--- a/lib/docker/image_manager.js
+++ b/lib/docker/image_manager.js
@@ -78,7 +78,7 @@ export default class ImageManager {
         let exists = await imageHandler.imageExists();
 
         if (!exists) {
-          await imageHandler.download();
+          await this.runtime.stats.timeGen('imageLoadTimeTotal', imageHandler.download());
         }
 
         return imageHandler.imageId;

--- a/lib/stats/series.js
+++ b/lib/stats/series.js
@@ -124,6 +124,34 @@ export const taskImage = new base.stats.Series({
   })
 });
 
+export const taskImageDownloadTime = new base.stats.Series({
+  name: 'task_image_download_time',
+  columns: Object.assign({}, BASE_WORKER_SCHEMA, {
+    duration: base.stats.types.Number
+  })
+});
+
+export const taskImageLoadTime = new base.stats.Series({
+  name: 'task_image_load_time',
+  columns: Object.assign({}, BASE_WORKER_SCHEMA, {
+    duration: base.stats.types.Number
+  })
+});
+
+export const dockerImageDownloadTime = new base.stats.Series({
+  name: 'docker_image_download_time',
+  columns: Object.assign({}, BASE_WORKER_SCHEMA, {
+    duration: base.stats.types.Number
+  })
+});
+
+export const imageLoadTimeTotal = new base.stats.Series({
+  name: 'image_load_time_total',
+  columns: Object.assign({}, BASE_WORKER_SCHEMA, {
+    duration: base.stats.types.Number
+  })
+});
+
 export const devicePhone = new base.stats.Series({
   name: 'task_device_phone',
   columns: Object.assign({}, BASE_WORKER_SCHEMA, {

--- a/test/garbage_collection_test.js
+++ b/test/garbage_collection_test.js
@@ -26,7 +26,12 @@ suite('garbage collection tests', function () {
       delayFactor: 15 * 1000,
       randomizationFactor: 0.25
     },
-    log: logger()
+    log: logger(),
+    stats: {
+      timeGen: async function (series, fn) {
+        return await fn;
+      }
+    }
   });
 
   function* getImageId(docker, imageName) {

--- a/test/garbage_collection_test.js
+++ b/test/garbage_collection_test.js
@@ -29,6 +29,7 @@ suite('garbage collection tests', function () {
     log: logger(),
     stats: {
       timeGen: async function (series, fn) {
+        assert(typeof fn.then === 'function', 'Function does not appear to be a promise');
         return await fn;
       }
     }
@@ -380,7 +381,10 @@ suite('garbage collection tests', function () {
 
     var stats = {
       record: function(stat) { return; },
-      timeGen: async (stat, fn) => { await fn; }
+      timeGen: async (stat, fn) => {
+        assert(typeof fn.then === 'function', 'Function does not appear to be a promise');
+        await fn;
+      }
     };
 
     var cache = new VolumeCache({

--- a/test/image_manager_test.js
+++ b/test/image_manager_test.js
@@ -17,6 +17,11 @@ const DOCKER_CONFIG = {
   randomizationFactor: 0.25
 };
 
+async function timeGen(series, fn) {
+  assert(typeof fn.then === 'function', 'Function does not appear to be a promise');
+  return await fn;
+}
+
 suite('Image Manager', () => {
   test('download docker image from registry', async () => {
     let image = 'gliderlabs/alpine:latest';
@@ -26,9 +31,7 @@ suite('Image Manager', () => {
       dockerConfig: DOCKER_CONFIG,
       log: createLogger(),
       stats: {
-        timeGen: async function (series, fn) {
-          return await fn;
-        }
+        timeGen: timeGen
       }
     };
 
@@ -58,9 +61,7 @@ suite('Image Manager', () => {
       dockerVolume: '/tmp',
       log: createLogger(),
       stats: {
-        timeGen: async function (series, fn) {
-          return await fn;
-        }
+        timeGen: timeGen
       }
     };
 
@@ -93,9 +94,7 @@ suite('Image Manager', () => {
       dockerVolume: '/tmp',
       log: createLogger(),
       stats: {
-        timeGen: async function (series, fn) {
-          return await fn;
-        }
+        timeGen: timeGen
       }
     };
 
@@ -126,9 +125,7 @@ suite('Image Manager', () => {
       dockerVolume: '/tmp',
       log: createLogger(),
       stats: {
-        timeGen: async function (series, fn) {
-          return await fn;
-        }
+        timeGen: timeGen
       }
     };
 
@@ -164,9 +161,7 @@ suite('Image Manager', () => {
       dockerVolume: '/tmp',
       log: createLogger(),
       stats: {
-        timeGen: async function (series, fn) {
-          return await fn;
-        }
+        timeGen: timeGen
       }
     };
 
@@ -196,9 +191,7 @@ suite('Image Manager', () => {
       dockerVolume: '/tmp',
       log: createLogger(),
       stats: {
-        timeGen: async function (series, fn) {
-          return await fn;
-        }
+        timeGen: timeGen
       }
     };
 
@@ -221,9 +214,7 @@ suite('Image Manager', () => {
       dockerVolume: '/tmp',
       log: createLogger(),
       stats: {
-        timeGen: async function (series, fn) {
-          return await fn;
-        }
+        timeGen: timeGen
       }
     };
 
@@ -252,9 +243,7 @@ suite('Image Manager', () => {
       dockerVolume: '/tmp',
       log: createLogger(),
       stats: {
-        timeGen: async function (series, fn) {
-          return await fn;
-        }
+        timeGen: timeGen
       }
     };
 
@@ -282,9 +271,7 @@ suite('Image Manager', () => {
       dockerVolume: '/tmp',
       log: createLogger(),
       stats: {
-        timeGen: async function (series, fn) {
-          return await fn;
-        }
+        timeGen: timeGen
       }
     };
 

--- a/test/image_manager_test.js
+++ b/test/image_manager_test.js
@@ -24,7 +24,12 @@ suite('Image Manager', () => {
     let runtime = {
       docker: docker,
       dockerConfig: DOCKER_CONFIG,
-      log: createLogger()
+      log: createLogger(),
+      stats: {
+        timeGen: async function (series, fn) {
+          return await fn;
+        }
+      }
     };
 
     let im = new ImageManager(runtime);
@@ -51,7 +56,12 @@ suite('Image Manager', () => {
       docker: docker,
       dockerConfig: DOCKER_CONFIG,
       dockerVolume: '/tmp',
-      log: createLogger()
+      log: createLogger(),
+      stats: {
+        timeGen: async function (series, fn) {
+          return await fn;
+        }
+      }
     };
 
     let im = new ImageManager(runtime);
@@ -81,7 +91,12 @@ suite('Image Manager', () => {
       docker: docker,
       dockerConfig: DOCKER_CONFIG,
       dockerVolume: '/tmp',
-      log: createLogger()
+      log: createLogger(),
+      stats: {
+        timeGen: async function (series, fn) {
+          return await fn;
+        }
+      }
     };
 
     let im = new ImageManager(runtime);
@@ -109,7 +124,12 @@ suite('Image Manager', () => {
       docker: docker,
       dockerConfig: DOCKER_CONFIG,
       dockerVolume: '/tmp',
-      log: createLogger()
+      log: createLogger(),
+      stats: {
+        timeGen: async function (series, fn) {
+          return await fn;
+        }
+      }
     };
 
     let im = new ImageManager(runtime);
@@ -142,7 +162,12 @@ suite('Image Manager', () => {
       docker: docker,
       dockerConfig: DOCKER_CONFIG,
       dockerVolume: '/tmp',
-      log: createLogger()
+      log: createLogger(),
+      stats: {
+        timeGen: async function (series, fn) {
+          return await fn;
+        }
+      }
     };
 
     let im = new ImageManager(runtime);
@@ -169,7 +194,12 @@ suite('Image Manager', () => {
       docker: docker,
       dockerConfig: DOCKER_CONFIG,
       dockerVolume: '/tmp',
-      log: createLogger()
+      log: createLogger(),
+      stats: {
+        timeGen: async function (series, fn) {
+          return await fn;
+        }
+      }
     };
 
     let im = new ImageManager(runtime);
@@ -189,7 +219,12 @@ suite('Image Manager', () => {
       docker: docker,
       dockerConfig: DOCKER_CONFIG,
       dockerVolume: '/tmp',
-      log: createLogger()
+      log: createLogger(),
+      stats: {
+        timeGen: async function (series, fn) {
+          return await fn;
+        }
+      }
     };
 
     let im = new ImageManager(runtime);
@@ -215,7 +250,12 @@ suite('Image Manager', () => {
       docker: docker,
       dockerConfig: DOCKER_CONFIG,
       dockerVolume: '/tmp',
-      log: createLogger()
+      log: createLogger(),
+      stats: {
+        timeGen: async function (series, fn) {
+          return await fn;
+        }
+      }
     };
 
     let im = new ImageManager(runtime);
@@ -240,7 +280,12 @@ suite('Image Manager', () => {
       docker: docker,
       dockerConfig: DOCKER_CONFIG,
       dockerVolume: '/tmp',
-      log: createLogger()
+      log: createLogger(),
+      stats: {
+        timeGen: async function (series, fn) {
+          return await fn;
+        }
+      }
     };
 
     let im = new ImageManager(runtime);


### PR DESCRIPTION
A considerable amount of time can be spent downloading and loading image.  This will allow us to report these metrics for downloading, loading (this is specific to task images), and the complete process.