### PR TITLE
Update aus4-admin.mozilla.org DNS hack with new IP address

### DIFF
--- a/lib/features/balrog_vpn_proxy.js
+++ b/lib/features/balrog_vpn_proxy.js
@@ -77,7 +77,7 @@ export default class BalrogVPNProxy {
         ExtraHosts: [
           // XXX: hack for now.  Problem in taskcluster-vpn-proxy where resolv.conf
           // isn't updated when vpn'ed in so name resolution does not work.
-          "aus4-admin.mozilla.org:10.8.81.74"
+          "aus4-admin.mozilla.org:52.26.16.60"
         ]
       }
     });


### PR DESCRIPTION
This needs updating after the transition to CloudOps.