### PR TITLE
Retry npm install during deployment process

### DIFF
--- a/deploy/packer/app/scripts/deploy.sh
+++ b/deploy/packer/app/scripts/deploy.sh
@@ -26,7 +26,21 @@ mkdir -p $target
 cd $target
 tar xzf $docker_worker_source -C $target --strip-components=1
 sudo chown -R $USER:$USER /home/ubuntu/docker_worker
-npm install --production
+
+retry_count=0
+max_retries=5
+until [ $retry_count -gt $max_retries ]; do
+    npm install --production && break
+    retry_count=$(($retry_count + 1))
+    sleep 5
+done
+
+if [ $retry_count -ge $max_retries ]; then
+    echo ""
+    echo "Error installing docker-worker packages"
+    exit -1
+fi
+
 npm rebuild
 sudo npm install -g babel@4.7.16
 


### PR DESCRIPTION
There are times where there might be an issue contact npm where a retry
would help.  This is specifically useful in the case where there is a
connection reset.