### PR TITLE
Update links in schema to point to updated URLs.

### DIFF
--- a/schemas/payload.json
+++ b/schemas/payload.json
@@ -187,7 +187,7 @@
     },
     "encryptedEnv": {
       "title": "List of encrypted environment variable mappings.",
-      "description": "List of base64 encoded asymmetric encrypted environment variables. See http://docs.taskcluster.net/docker-worker/#encrypted-environment-variables",
+      "description": "List of base64 encoded asymmetric encrypted environment variables. See https://docs.taskcluster.net/manual/execution/workers/docker-worker#encrypted-environment-variables",
       "type": "array",
       "items": {
         "title": "Base64 encoded encrypted environment variable object.",
@@ -210,7 +210,7 @@
     "graphs": {
       "type": "array",
       "title": "Paths (in the container) to a json files which are used to extend the task graph",
-      "description": "Contents of file are used to extend the graph (if this task was part of a graph). See http://docs.taskcluster.net/scheduler/api-docs/#extendTaskGraph",
+      "description": "Contents of file are used to extend the graph (if this task was part of a graph). See https://docs.taskcluster.net/reference/platform/scheduler/api-docs#extendTaskGraph",
       "items": {
         "title": "Individual path to graph extension point.",
         "type": "string"


### PR DESCRIPTION
The schema contains two links to the docs which have been updated. The link
about encrypted environment vars was busted, the other link about extended task
graph was okay, due to redirects. I've updated both to fix the busted one and so
they're both consistent.