### PR TITLE
Remove dependency from aws-sdk-promise. r=jhford

### DIFF
--- a/bin/upload-schema.js
+++ b/bin/upload-schema.js
@@ -6,7 +6,7 @@ resources. That and the fact that we could have thousands of workers makes
 auto pushing schema's tricky. For now this script does the uploads manually.
 */
 
-var aws = require('aws-sdk-promise');
+var aws = require('aws-sdk');
 var fs = require('fs');
 
 var base = require('taskcluster-base');

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3,35 +3,35 @@
   "version": "0.0.0",
   "dependencies": {
     "aws-sdk": {
-      "version": "2.3.7",
-      "from": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.3.7.tgz",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.3.7.tgz",
+      "version": "2.5.5",
+      "from": "aws-sdk@2.5.5",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.5.5.tgz",
       "dependencies": {
         "sax": {
           "version": "1.1.5",
-          "from": "https://registry.npmjs.org/sax/-/sax-1.1.5.tgz",
+          "from": "sax@1.1.5",
           "resolved": "https://registry.npmjs.org/sax/-/sax-1.1.5.tgz"
         },
         "xml2js": {
           "version": "0.4.15",
-          "from": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.15.tgz",
+          "from": "xml2js@0.4.15",
           "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.15.tgz"
         },
         "xmlbuilder": {
           "version": "2.6.2",
-          "from": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-2.6.2.tgz",
+          "from": "xmlbuilder@2.6.2",
           "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-2.6.2.tgz",
           "dependencies": {
             "lodash": {
               "version": "3.5.0",
-              "from": "https://registry.npmjs.org/lodash/-/lodash-3.5.0.tgz",
+              "from": "lodash@>=3.5.0 <3.6.0",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.5.0.tgz"
             }
           }
         },
         "jmespath": {
           "version": "0.15.0",
-          "from": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
+          "from": "jmespath@0.15.0",
           "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz"
         }
       }
@@ -7101,22 +7101,22 @@
     },
     "taskcluster-lib-monitor": {
       "version": "4.2.0",
-      "from": "taskcluster-lib-monitor@*",
+      "from": "https://registry.npmjs.org/taskcluster-lib-monitor/-/taskcluster-lib-monitor-4.2.0.tgz",
       "resolved": "https://registry.npmjs.org/taskcluster-lib-monitor/-/taskcluster-lib-monitor-4.2.0.tgz",
       "dependencies": {
         "assert": {
           "version": "1.4.1",
-          "from": "assert@>=1.3.0 <2.0.0",
+          "from": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz",
           "resolved": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz",
           "dependencies": {
             "util": {
               "version": "0.10.3",
-              "from": "util@0.10.3",
+              "from": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
               "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@2.0.1",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
@@ -7125,76 +7125,76 @@
         },
         "babel-runtime": {
           "version": "6.11.6",
-          "from": "babel-runtime@>=6.0.0 <7.0.0",
+          "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.11.6.tgz",
           "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.11.6.tgz",
           "dependencies": {
             "core-js": {
               "version": "2.4.1",
-              "from": "core-js@>=2.4.0 <3.0.0",
+              "from": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
               "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
             },
             "regenerator-runtime": {
               "version": "0.9.5",
-              "from": "regenerator-runtime@>=0.9.5 <0.10.0",
+              "from": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.9.5.tgz",
               "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.9.5.tgz"
             }
           }
         },
         "lodash": {
           "version": "4.15.0",
-          "from": "lodash@>=4.5.1 <5.0.0",
+          "from": "https://registry.npmjs.org/lodash/-/lodash-4.15.0.tgz",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.15.0.tgz"
         },
         "raven": {
           "version": "0.11.0",
-          "from": "raven@>=0.11.0 <0.12.0",
+          "from": "https://registry.npmjs.org/raven/-/raven-0.11.0.tgz",
           "resolved": "https://registry.npmjs.org/raven/-/raven-0.11.0.tgz",
           "dependencies": {
             "cookie": {
               "version": "0.1.0",
-              "from": "cookie@0.1.0",
+              "from": "https://registry.npmjs.org/cookie/-/cookie-0.1.0.tgz",
               "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.0.tgz"
             },
             "lsmod": {
               "version": "1.0.0",
-              "from": "lsmod@1.0.0",
+              "from": "https://registry.npmjs.org/lsmod/-/lsmod-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/lsmod/-/lsmod-1.0.0.tgz"
             },
             "node-uuid": {
               "version": "1.4.7",
-              "from": "node-uuid@>=1.4.1 <1.5.0",
+              "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
               "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
             },
             "stack-trace": {
               "version": "0.0.7",
-              "from": "stack-trace@0.0.7",
+              "from": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.7.tgz",
               "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.7.tgz"
             }
           }
         },
         "statsum": {
           "version": "0.5.1",
-          "from": "statsum@>=0.5.1 <0.6.0",
+          "from": "https://registry.npmjs.org/statsum/-/statsum-0.5.1.tgz",
           "resolved": "https://registry.npmjs.org/statsum/-/statsum-0.5.1.tgz",
           "dependencies": {
             "get-stream": {
               "version": "2.3.0",
-              "from": "get-stream@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.0.tgz",
               "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.0.tgz",
               "dependencies": {
                 "object-assign": {
                   "version": "4.1.0",
-                  "from": "object-assign@>=4.0.1 <5.0.0",
+                  "from": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
                 },
                 "pinkie-promise": {
                   "version": "2.0.1",
-                  "from": "pinkie-promise@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
                   "dependencies": {
                     "pinkie": {
                       "version": "2.0.4",
-                      "from": "pinkie@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
                       "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
                     }
                   }
@@ -7203,52 +7203,52 @@
             },
             "jsonwebtoken": {
               "version": "5.7.0",
-              "from": "jsonwebtoken@>=5.7.0 <6.0.0",
+              "from": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-5.7.0.tgz",
               "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-5.7.0.tgz",
               "dependencies": {
                 "jws": {
                   "version": "3.1.3",
-                  "from": "jws@>=3.0.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/jws/-/jws-3.1.3.tgz",
                   "resolved": "https://registry.npmjs.org/jws/-/jws-3.1.3.tgz",
                   "dependencies": {
                     "base64url": {
                       "version": "1.0.6",
-                      "from": "base64url@>=1.0.4 <1.1.0",
+                      "from": "https://registry.npmjs.org/base64url/-/base64url-1.0.6.tgz",
                       "resolved": "https://registry.npmjs.org/base64url/-/base64url-1.0.6.tgz",
                       "dependencies": {
                         "concat-stream": {
                           "version": "1.4.10",
-                          "from": "concat-stream@>=1.4.7 <1.5.0",
+                          "from": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz",
                           "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz",
                           "dependencies": {
                             "inherits": {
                               "version": "2.0.1",
-                              "from": "inherits@>=2.0.1 <2.1.0",
+                              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                             },
                             "typedarray": {
                               "version": "0.0.6",
-                              "from": "typedarray@>=0.0.5 <0.1.0",
+                              "from": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
                               "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
                             },
                             "readable-stream": {
                               "version": "1.1.14",
-                              "from": "readable-stream@>=1.1.9 <1.2.0",
+                              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
                               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
                               "dependencies": {
                                 "core-util-is": {
                                   "version": "1.0.2",
-                                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                                 },
                                 "isarray": {
                                   "version": "0.0.1",
-                                  "from": "isarray@0.0.1",
+                                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                                 },
                                 "string_decoder": {
                                   "version": "0.10.31",
-                                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                                 }
                               }
@@ -7257,49 +7257,49 @@
                         },
                         "meow": {
                           "version": "2.0.0",
-                          "from": "meow@>=2.0.0 <2.1.0",
+                          "from": "https://registry.npmjs.org/meow/-/meow-2.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/meow/-/meow-2.0.0.tgz",
                           "dependencies": {
                             "camelcase-keys": {
                               "version": "1.0.0",
-                              "from": "camelcase-keys@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
                               "dependencies": {
                                 "camelcase": {
                                   "version": "1.2.1",
-                                  "from": "camelcase@>=1.0.1 <2.0.0",
+                                  "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
                                   "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
                                 },
                                 "map-obj": {
                                   "version": "1.0.1",
-                                  "from": "map-obj@>=1.0.0 <2.0.0",
+                                  "from": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
                                   "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
                                 }
                               }
                             },
                             "indent-string": {
                               "version": "1.2.2",
-                              "from": "indent-string@>=1.1.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.2.tgz",
                               "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.2.tgz",
                               "dependencies": {
                                 "get-stdin": {
                                   "version": "4.0.1",
-                                  "from": "get-stdin@>=4.0.1 <5.0.0",
+                                  "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
                                   "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
                                 },
                                 "repeating": {
                                   "version": "1.1.3",
-                                  "from": "repeating@>=1.1.0 <2.0.0",
+                                  "from": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
                                   "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
                                   "dependencies": {
                                     "is-finite": {
                                       "version": "1.0.1",
-                                      "from": "is-finite@>=1.0.0 <2.0.0",
+                                      "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                                       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                                       "dependencies": {
                                         "number-is-nan": {
                                           "version": "1.0.0",
-                                          "from": "number-is-nan@>=1.0.0 <2.0.0",
+                                          "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
                                           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                                         }
                                       }
@@ -7310,12 +7310,12 @@
                             },
                             "minimist": {
                               "version": "1.2.0",
-                              "from": "minimist@>=1.1.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
                               "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
                             },
                             "object-assign": {
                               "version": "1.0.0",
-                              "from": "object-assign@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/object-assign/-/object-assign-1.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-1.0.0.tgz"
                             }
                           }
@@ -7324,22 +7324,22 @@
                     },
                     "jwa": {
                       "version": "1.1.3",
-                      "from": "jwa@>=1.1.2 <2.0.0",
+                      "from": "https://registry.npmjs.org/jwa/-/jwa-1.1.3.tgz",
                       "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.1.3.tgz",
                       "dependencies": {
                         "buffer-equal-constant-time": {
                           "version": "1.0.1",
-                          "from": "buffer-equal-constant-time@>=1.0.1 <2.0.0",
+                          "from": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz"
                         },
                         "ecdsa-sig-formatter": {
                           "version": "1.0.7",
-                          "from": "ecdsa-sig-formatter@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.7.tgz",
                           "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.7.tgz",
                           "dependencies": {
                             "base64-url": {
                               "version": "1.3.2",
-                              "from": "base64-url@>=1.2.1 <2.0.0",
+                              "from": "https://registry.npmjs.org/base64-url/-/base64-url-1.3.2.tgz",
                               "resolved": "https://registry.npmjs.org/base64-url/-/base64-url-1.3.2.tgz"
                             }
                           }
@@ -7350,108 +7350,108 @@
                 },
                 "ms": {
                   "version": "0.7.1",
-                  "from": "ms@>=0.7.1 <0.8.0",
+                  "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
                   "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                 },
                 "xtend": {
                   "version": "4.0.1",
-                  "from": "xtend@>=4.0.1 <5.0.0",
+                  "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
                 }
               }
             },
             "url-join": {
               "version": "0.0.1",
-              "from": "url-join@>=0.0.1 <0.0.2",
+              "from": "https://registry.npmjs.org/url-join/-/url-join-0.0.1.tgz",
               "resolved": "https://registry.npmjs.org/url-join/-/url-join-0.0.1.tgz"
             },
             "uuid": {
               "version": "2.0.2",
-              "from": "uuid@>=2.0.2 <3.0.0",
+              "from": "https://registry.npmjs.org/uuid/-/uuid-2.0.2.tgz",
               "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.2.tgz"
             }
           }
         },
         "taskcluster-client": {
           "version": "1.3.0",
-          "from": "taskcluster-client@>=1.0.1 <2.0.0",
+          "from": "https://registry.npmjs.org/taskcluster-client/-/taskcluster-client-1.3.0.tgz",
           "resolved": "https://registry.npmjs.org/taskcluster-client/-/taskcluster-client-1.3.0.tgz",
           "dependencies": {
             "lodash": {
               "version": "3.10.1",
-              "from": "lodash@>=3.6.0 <4.0.0",
+              "from": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
             },
             "superagent": {
               "version": "1.7.2",
-              "from": "superagent@>=1.7.0 <1.8.0",
+              "from": "https://registry.npmjs.org/superagent/-/superagent-1.7.2.tgz",
               "resolved": "https://registry.npmjs.org/superagent/-/superagent-1.7.2.tgz",
               "dependencies": {
                 "qs": {
                   "version": "2.3.3",
-                  "from": "qs@2.3.3",
+                  "from": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz",
                   "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
                 },
                 "formidable": {
                   "version": "1.0.17",
-                  "from": "formidable@>=1.0.14 <1.1.0",
+                  "from": "https://registry.npmjs.org/formidable/-/formidable-1.0.17.tgz",
                   "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.0.17.tgz"
                 },
                 "component-emitter": {
                   "version": "1.2.1",
-                  "from": "component-emitter@>=1.2.0 <1.3.0",
+                  "from": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
                   "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz"
                 },
                 "methods": {
                   "version": "1.1.2",
-                  "from": "methods@>=1.1.1 <1.2.0",
+                  "from": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
                   "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz"
                 },
                 "cookiejar": {
                   "version": "2.0.6",
-                  "from": "cookiejar@2.0.6",
+                  "from": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.0.6.tgz",
                   "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.0.6.tgz"
                 },
                 "reduce-component": {
                   "version": "1.0.1",
-                  "from": "reduce-component@1.0.1",
+                  "from": "https://registry.npmjs.org/reduce-component/-/reduce-component-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/reduce-component/-/reduce-component-1.0.1.tgz"
                 },
                 "extend": {
                   "version": "3.0.0",
-                  "from": "extend@3.0.0",
+                  "from": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
                 },
                 "form-data": {
                   "version": "0.2.0",
-                  "from": "form-data@0.2.0",
+                  "from": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
                   "dependencies": {
                     "async": {
                       "version": "0.9.2",
-                      "from": "async@>=0.9.0 <0.10.0",
+                      "from": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
                       "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
                     },
                     "combined-stream": {
                       "version": "0.0.7",
-                      "from": "combined-stream@>=0.0.4 <0.1.0",
+                      "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
                       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
                       "dependencies": {
                         "delayed-stream": {
                           "version": "0.0.5",
-                          "from": "delayed-stream@0.0.5",
+                          "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
                           "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
                         }
                       }
                     },
                     "mime-types": {
                       "version": "2.0.14",
-                      "from": "mime-types@>=2.0.3 <2.1.0",
+                      "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
                       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
                       "dependencies": {
                         "mime-db": {
                           "version": "1.12.0",
-                          "from": "mime-db@>=1.12.0 <1.13.0",
+                          "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz",
                           "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz"
                         }
                       }
@@ -7460,27 +7460,27 @@
                 },
                 "readable-stream": {
                   "version": "1.0.27-1",
-                  "from": "readable-stream@1.0.27-1",
+                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.27-1.tgz",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.27-1.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.2",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                     },
                     "isarray": {
                       "version": "0.0.1",
-                      "from": "isarray@0.0.1",
+                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
@@ -7489,164 +7489,164 @@
             },
             "superagent-hawk": {
               "version": "0.0.6",
-              "from": "superagent-hawk@>=0.0.6 <0.0.7",
+              "from": "https://registry.npmjs.org/superagent-hawk/-/superagent-hawk-0.0.6.tgz",
               "resolved": "https://registry.npmjs.org/superagent-hawk/-/superagent-hawk-0.0.6.tgz",
               "dependencies": {
                 "hawk": {
                   "version": "1.0.0",
-                  "from": "hawk@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/hawk/-/hawk-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.0.0.tgz",
                   "dependencies": {
                     "hoek": {
                       "version": "0.9.1",
-                      "from": "hoek@>=0.9.0 <0.10.0",
+                      "from": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz",
                       "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
                     },
                     "boom": {
                       "version": "0.4.2",
-                      "from": "boom@>=0.4.0 <0.5.0",
+                      "from": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz",
                       "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
                     },
                     "cryptiles": {
                       "version": "0.2.2",
-                      "from": "cryptiles@>=0.2.0 <0.3.0",
+                      "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz",
                       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
                     },
                     "sntp": {
                       "version": "0.2.4",
-                      "from": "sntp@>=0.2.0 <0.3.0",
+                      "from": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz",
                       "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
                     }
                   }
                 },
                 "qs": {
                   "version": "0.6.6",
-                  "from": "qs@>=0.6.6 <0.7.0",
+                  "from": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz",
                   "resolved": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz"
                 }
               }
             },
             "amqplib": {
               "version": "0.4.2",
-              "from": "amqplib@>=0.4.1 <0.5.0",
+              "from": "https://registry.npmjs.org/amqplib/-/amqplib-0.4.2.tgz",
               "resolved": "https://registry.npmjs.org/amqplib/-/amqplib-0.4.2.tgz",
               "dependencies": {
                 "bitsyntax": {
                   "version": "0.0.4",
-                  "from": "bitsyntax@>=0.0.4 <0.1.0",
+                  "from": "https://registry.npmjs.org/bitsyntax/-/bitsyntax-0.0.4.tgz",
                   "resolved": "https://registry.npmjs.org/bitsyntax/-/bitsyntax-0.0.4.tgz"
                 },
                 "buffer-more-ints": {
                   "version": "0.0.2",
-                  "from": "buffer-more-ints@0.0.2",
+                  "from": "https://registry.npmjs.org/buffer-more-ints/-/buffer-more-ints-0.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/buffer-more-ints/-/buffer-more-ints-0.0.2.tgz"
                 },
                 "readable-stream": {
                   "version": "1.1.14",
-                  "from": "readable-stream@>=1.0.0 <2.0.0 >=1.1.9",
+                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.2",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                     },
                     "isarray": {
                       "version": "0.0.1",
-                      "from": "isarray@0.0.1",
+                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
                 },
                 "when": {
                   "version": "3.6.4",
-                  "from": "when@>=3.6.2 <3.7.0",
+                  "from": "https://registry.npmjs.org/when/-/when-3.6.4.tgz",
                   "resolved": "https://registry.npmjs.org/when/-/when-3.6.4.tgz"
                 }
               }
             },
             "promise": {
               "version": "6.1.0",
-              "from": "promise@>=6.1.0 <7.0.0",
+              "from": "https://registry.npmjs.org/promise/-/promise-6.1.0.tgz",
               "resolved": "https://registry.npmjs.org/promise/-/promise-6.1.0.tgz",
               "dependencies": {
                 "asap": {
                   "version": "1.0.0",
-                  "from": "asap@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/asap/-/asap-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/asap/-/asap-1.0.0.tgz"
                 }
               }
             },
             "hawk": {
               "version": "2.3.1",
-              "from": "hawk@>=2.3.1 <3.0.0",
+              "from": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
               "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
               "dependencies": {
                 "hoek": {
                   "version": "2.16.3",
-                  "from": "hoek@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
                   "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
                 },
                 "boom": {
                   "version": "2.10.1",
-                  "from": "boom@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
                   "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
                 },
                 "cryptiles": {
                   "version": "2.0.5",
-                  "from": "cryptiles@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
                   "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
                 },
                 "sntp": {
                   "version": "1.0.9",
-                  "from": "sntp@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
                   "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
                 }
               }
             },
             "url-join": {
               "version": "0.0.1",
-              "from": "url-join@>=0.0.1 <0.0.2",
+              "from": "https://registry.npmjs.org/url-join/-/url-join-0.0.1.tgz",
               "resolved": "https://registry.npmjs.org/url-join/-/url-join-0.0.1.tgz"
             },
             "sockjs-client": {
               "version": "1.1.1",
-              "from": "sockjs-client@>=1.0.3 <2.0.0",
+              "from": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.1.1.tgz",
               "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.1.1.tgz",
               "dependencies": {
                 "eventsource": {
                   "version": "0.1.6",
-                  "from": "eventsource@>=0.1.6 <0.2.0",
+                  "from": "https://registry.npmjs.org/eventsource/-/eventsource-0.1.6.tgz",
                   "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-0.1.6.tgz",
                   "dependencies": {
                     "original": {
                       "version": "1.0.0",
-                      "from": "original@>=0.0.5",
+                      "from": "https://registry.npmjs.org/original/-/original-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/original/-/original-1.0.0.tgz",
                       "dependencies": {
                         "url-parse": {
                           "version": "1.0.5",
-                          "from": "url-parse@>=1.0.0 <1.1.0",
+                          "from": "https://registry.npmjs.org/url-parse/-/url-parse-1.0.5.tgz",
                           "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.0.5.tgz",
                           "dependencies": {
                             "querystringify": {
                               "version": "0.0.4",
-                              "from": "querystringify@>=0.0.0 <0.1.0",
+                              "from": "https://registry.npmjs.org/querystringify/-/querystringify-0.0.4.tgz",
                               "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-0.0.4.tgz"
                             },
                             "requires-port": {
                               "version": "1.0.0",
-                              "from": "requires-port@>=1.0.0 <1.1.0",
+                              "from": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz"
                             }
                           }
@@ -7657,17 +7657,17 @@
                 },
                 "faye-websocket": {
                   "version": "0.11.0",
-                  "from": "faye-websocket@>=0.11.0 <0.12.0",
+                  "from": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.0.tgz",
                   "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.0.tgz",
                   "dependencies": {
                     "websocket-driver": {
                       "version": "0.6.5",
-                      "from": "websocket-driver@>=0.5.1",
+                      "from": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.6.5.tgz",
                       "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.6.5.tgz",
                       "dependencies": {
                         "websocket-extensions": {
                           "version": "0.1.1",
-                          "from": "websocket-extensions@>=0.1.1",
+                          "from": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.1.tgz",
                           "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.1.tgz"
                         }
                       }
@@ -7676,27 +7676,27 @@
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <3.0.0",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "json3": {
                   "version": "3.3.2",
-                  "from": "json3@>=3.3.2 <4.0.0",
+                  "from": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
                   "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz"
                 },
                 "url-parse": {
                   "version": "1.1.3",
-                  "from": "url-parse@>=1.1.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/url-parse/-/url-parse-1.1.3.tgz",
                   "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.1.3.tgz",
                   "dependencies": {
                     "querystringify": {
                       "version": "0.0.4",
-                      "from": "querystringify@>=0.0.0 <0.1.0",
+                      "from": "https://registry.npmjs.org/querystringify/-/querystringify-0.0.4.tgz",
                       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-0.0.4.tgz"
                     },
                     "requires-port": {
                       "version": "1.0.0",
-                      "from": "requires-port@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz"
                     }
                   }
@@ -7707,17 +7707,17 @@
         },
         "usage": {
           "version": "0.7.1",
-          "from": "usage@>=0.7.1 <0.8.0",
+          "from": "https://registry.npmjs.org/usage/-/usage-0.7.1.tgz",
           "resolved": "https://registry.npmjs.org/usage/-/usage-0.7.1.tgz",
           "dependencies": {
             "bindings": {
               "version": "1.2.1",
-              "from": "bindings@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz",
               "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz"
             },
             "nan": {
               "version": "2.4.0",
-              "from": "nan@>=2.0.9 <3.0.0",
+              "from": "https://registry.npmjs.org/nan/-/nan-2.4.0.tgz",
               "resolved": "https://registry.npmjs.org/nan/-/nan-2.4.0.tgz"
             }
           }

--- a/package.json
+++ b/package.json
@@ -20,8 +20,7 @@
   "bugs": "https://github.com/taskcluster/docker-worker/issues",
   "homepage": "https://github.com/taskcluster/docker-worker",
   "dependencies": {
-    "aws-sdk": "^2.1.5",
-    "aws-sdk-promise": "0.0.2",
+    "aws-sdk": "^2.5.5",
     "azure-storage": "^0.3.0",
     "babel": "^4.7",
     "cli-color": "^0.3.2",


### PR DESCRIPTION
Amazon has added the .promise() function to aws-sdk and aws-sdk-promise
isn't required anymore. Furthermore, aws-sdk-promise is going to be
deprecated. Details: http://tinyurl.com/hry2fa3