### PR TITLE
Switch to new version of taskcluster-lib-monitor. r=jonasfj

### DIFF
--- a/bin/worker.js
+++ b/bin/worker.js
@@ -8,6 +8,7 @@ var base = require('taskcluster-base');
 var createLogger = require('../lib/log').createLogger;
 var debug = require('debug')('docker-worker:bin:worker');
 var _ = require('lodash');
+var monitoring = require('taskcluster-lib-monitor');
 
 var Runtime = require('../lib/runtime');
 var TaskListener = require('../lib/task_listener');
@@ -176,7 +177,7 @@ async () => {
   // level docker-worker components.
   config.docker = require('../lib/docker')();
 
-  let monitor = await base.monitor({
+  let monitor = await monitoring({
     project: 'docker-worker',
     credentials: config.taskcluster,
     mock: profile === 'test',

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "taskcluster-azure-blobstream": "^0.3.0",
     "taskcluster-base": "^0.13.0",
     "taskcluster-client": "^0.22.0",
+    "taskcluster-lib-monitor": "^4.2.0",
     "taskcluster-task-factory": "^0.6.1",
     "temporary": "0.0.8",
     "testdroid-client": "0.0.7",

--- a/test/garbage_collection_test.js
+++ b/test/garbage_collection_test.js
@@ -14,6 +14,7 @@ suite('garbage collection tests', function () {
   var rmrf = require('rimraf');
   var removeImage = require('../lib/util/remove_image').removeImage;
   var base = require('taskcluster-base');
+  var monitoring = require('taskcluster-lib-monitor');
 
   var IMAGE = 'taskcluster/test-ubuntu';
 
@@ -33,7 +34,7 @@ suite('garbage collection tests', function () {
   }
 
   setup(co(function* () {
-    monitor = yield base.monitor({
+    monitor = yield monitoring({
         credentials: {},
         project: 'docker-worker-tests',
         mock: true

--- a/test/image_manager_test.js
+++ b/test/image_manager_test.js
@@ -9,6 +9,7 @@ import slugid from 'slugid';
 import {createLogger} from '../lib/log';
 import {NAMESPACE, TASK_ID} from './fixtures/image_artifacts';
 import taskcluster from 'taskcluster-client';
+import monitoring from 'taskcluster-lib-monitor';
 
 let docker = Docker();
 let monitor;
@@ -22,7 +23,7 @@ const DOCKER_CONFIG = {
 
 suite('Image Manager', () => {
   setup(async () => {
-    monitor = await base.monitor({
+    monitor = await monitoring({
         credentials: {},
         project: 'docker-worker-tests',
         mock: true

--- a/test/volume_cache_test.js
+++ b/test/volume_cache_test.js
@@ -13,6 +13,7 @@ suite('volume cache test', function () {
   var co = require('co');
   var cmd = require('./integration/helper/cmd');
   var base = require('taskcluster-base');
+  var monitoring = require('taskcluster-lib-monitor');
 
   // Location on the machine running the test where the cache will live
   var localCacheDir = path.join('/tmp', 'test-cache');
@@ -29,7 +30,7 @@ suite('volume cache test', function () {
   var IMAGE = 'taskcluster/test-ubuntu';
 
   setup(co(function* () {
-    monitor = yield base.monitor({
+    monitor = yield monitoring({
         credentials: {},
         project: 'docker-worker-tests',
         mock: true


### PR DESCRIPTION
The taskcluster-base version used in docker-worker has a very old
lib-monitor library. As upgrading taskluster-base is quite some work, we
use taskcluster-lib-monitor directly now.