### PR TITLE
Only run a full gc sweep when no tasks are running

### DIFF
--- a/lib/gc.js
+++ b/lib/gc.js
@@ -200,7 +200,6 @@ GarbageCollector.prototype = {
   },
 
   sweep: async function (full=false) {
-    clearTimeout(this.sweepTimeoutId);
     this.emit('gc:sweep:start');
     this.log('garbage collection started');
     await this.markStaleContainers();

--- a/lib/gc.js
+++ b/lib/gc.js
@@ -41,8 +41,6 @@ function GarbageCollector(config) {
   this.log = config.log;
   this.monitor = config.monitor;
   this.taskListener = config.taskListener;
-  // Garbage collection interval in milliseconds
-  this.interval = config.interval || 60 * 1000;
   // Minimum diskspace required per task in bytes
   this.diskspaceThreshold = config.diskspaceThreshold || 10 * 1000000000;
   // Time in milliseconds until image is considered expired
@@ -52,7 +50,6 @@ function GarbageCollector(config) {
   this.ignoredContainers = [];
   this.markedImages = {};
   this.retries = 5;
-  this.scheduleSweep(this.interval);
   this.managers = [];
   EventEmitter.call(this);
 }
@@ -202,11 +199,7 @@ GarbageCollector.prototype = {
     }
   },
 
-  scheduleSweep: function (interval) {
-    this.sweepTimeoutId = setTimeout(this.sweep.bind(this), interval);
-  },
-
-  sweep: async function () {
+  sweep: async function (full=false) {
     clearTimeout(this.sweepTimeoutId);
     this.emit('gc:sweep:start');
     this.log('garbage collection started');
@@ -234,7 +227,10 @@ GarbageCollector.prototype = {
                           'Removing only expired images.'
                 });
     }
-    await this.removeUnusedImages(exceedsThreshold);
+
+    if (full) {
+      await this.removeUnusedImages(exceedsThreshold);
+    }
 
     for (var i = 0; i < this.managers.length; i++) {
       await this.managers[i].clear(exceedsThreshold);
@@ -242,7 +238,6 @@ GarbageCollector.prototype = {
 
     this.log('garbage collection finished');
     this.emit('gc:sweep:stop');
-    this.scheduleSweep(this.interval);
   }
 };
 

--- a/lib/task_listener.js
+++ b/lib/task_listener.js
@@ -158,7 +158,13 @@ export default class TaskListener extends EventEmitter {
 
   async getTasks() {
     let availableCapacity = await this.availableCapacity();
-    if (availableCapacity === 0)  return;
+    if (availableCapacity === 0) {
+      return;
+    }
+
+    // Run a garbage collection cycle to clean up containers and release volumes.
+    // Only run a full garbage collection cycle if no tasks are running.
+    await this.runtime.gc.sweep(this.runningTasks.length === 0);
 
     var exceedsThreshold = await exceedsDiskspaceThreshold(
       this.runtime.dockerVolume,


### PR DESCRIPTION
Most things can be cleaned up while tasks are still running,
such as containers that have exited, and volumes no longer in use.
However, attempting to remove images that might be running or have
layers used by an image currently being loaded will cause pain in the
long run.