### PR TITLE
Refactor to use queue.claimWork

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -123,12 +123,6 @@ defaults:
     # Ideally we want to keep the period less than double the average task but more than the runtime of
     # most (say, ~75%) of tasks.
     slowdownDivisor: 3
-    # If signed url for queue expires within now()+expiration, refresh queues
-    expiration: 300000
-    # Number of times to retry requests to the task queue
-    maxRetries: 5
-    # Amount of time to wait between retries
-    requestRetryInterval: 2000
 
   #Registries which we can authenticate against for pulls:
   #  registries: {

--- a/lib/queueservice.js
+++ b/lib/queueservice.js
@@ -1,45 +1,8 @@
-import xml2js from 'xml2js';
 import Debug from 'debug';
-import request from 'superagent-promise';
-import Promise from 'promise';
 import assert from 'assert';
 
 const MAX_MESSAGES_PER_REQUEST = 32;
-const parseXmlString = Promise.denodeify(xml2js.parseString.bind(xml2js));
-
 let debug = Debug('taskcluster-docker-worker:queueService');
-
-async function sleep(duration) {
-  return new Promise(accept => setTimeout(accept, duration));
-}
-
-async function makeRequest(method, url, retries, retryInterval, payload) {
-  method = method.toUpperCase();
-  while (--retries >= 0) {
-    try {
-      debug(`requesting: ${url}`);
-      let req = request(method, url);
-
-      if (payload) req.send(payload);
-
-      let response = await req.buffer().end();
-
-      if (!response.ok) {
-        let error = new Error(response.text);
-        error.statusCode = response.status;
-        throw error;
-      }
-
-      return response;
-    } catch (e) {
-      debug(`Error requesting ${url}. ${e.stack || e} status code: ${e.statusCode} Retries left: ${retries}`);
-      if (retries === 0) {
-        throw new Error(`Could not complete request. status code: ${e.statusCode} ${e.stack || e}`);
-      }
-    }
-    await sleep(retryInterval);
-  }
-}
 
 /**
  * Create a task queue that will poll for queues that could contain messages and
@@ -72,68 +35,18 @@ export default class TaskQueue {
     assert(config.provisionerId, 'Provisioner ID is required');
     assert(config.queue, 'Instance of taskcluster queue is required');
     assert(config.log, 'Logger is required');
-    assert(config.task.dequeueCount, 'Dequeue count is required');
-    assert(config.taskQueue.expiration, 'Queue expiration time in miliseconds is required');
     this.queues = null;
     this.queue = config.queue;
     this.workerType = config.workerType;
     this.provisionerId = config.provisionerId;
+    this.workerGroup = config.workerGroup;
+    this.workerId = config.workerId;
     this.client = config.queue;
     this.log = config.log;
-    this.dequeueCount = config.task.dequeueCount;
-    this.queueExpiration = config.taskQueue.expiration;
-    this.maxRetries = config.taskQueue.maxRetries || 5;
-    this.requestRetryInterval = config.taskQueue.requestRetryInterval || 2 * 1000;
-    this.claimConfig = {
-      workerId: config.workerId,
-      workerGroup: config.workerGroup
-    };
   }
 
   /**
-   * Attemts to claim the task.  Tasks that cannot be claimed because of 4xx
-   * errors will be removed from the queue because the are either not pending or
-   * claimed by another worker.
-   *
-   * @param {Object} task - Contains taskId and runId
-   *
-   * @returns {Object} claim
-   */
-  async claimTask(task) {
-    let claim;
-    try {
-      claim = await this.queue.claimTask(task.taskId, task.runId, this.claimConfig)
-
-      this.log('claim task', {
-        taskId: task.taskId,
-        runId: task.runId
-      });
-    }
-    catch (e) {
-      // Server error or 401 Authentication errors should stop trying to claim tasks
-      // and not delete the message from the queue
-      if (!(400 <= e.statusCode && e.statusCode < 500) || e.statusCode === 401) {
-        throw e;
-      }
-
-      this.log('claim task error', {
-        taskId: task.taskId,
-        runId: task.runId,
-        err: e,
-        stack: e.stack
-      });
-    }
-
-    // Delete message from the queue if it's been claimed or request
-    // returned 4xx (except 401)
-    await this.deleteTaskFromQueue(task);
-    return claim;
-  }
-
-  /**
-   * Queue will make an attempt to claim as much work as capacity allows.  Queues
-   * will be tried in the order of priority until either the queues have no more messages
-   * or the number of claimed tasks equals available capacity
+   * Queue will make an attempt to claim as much work as capacity allows.
    *
    * @param {Number} capacity - Number of tasks the worker is able to work on
    *
@@ -141,132 +54,17 @@ export default class TaskQueue {
    */
   async claimWork(capacity) {
     debug(`polling for ${capacity} tasks`);
-    let claims = [];
-
-    let queues = (await this.getQueues()).queues;
-    for(let queue of queues) {
-      if (claims.length >= capacity) break;
-      // Keep polling queue until enough tasks were claimed or there are no more
-      // tasks in the queue
-      // Move onto the next queue if more tasks are needed but current queue is exhausted
-      // This ensures that as many tasks as possible are consumed from the highest priority
-      // queue
-      while(claims.length < capacity) {
-        let tasksNeeded = capacity - claims.length;
-        let tasks = await this.getTasksFromQueue(queue, tasksNeeded);
-        if (!tasks.length) break;
-        let newClaims = await Promise.all(tasks.map(async (task) => {
-          return await this.claimTask(task);
-        }));
-
-        // Filter out entries that are not actual claims because of an error
-        newClaims = newClaims.filter((claim) => { return claim; });
-        claims = claims.concat(newClaims);
-      }
-    }
-    debug(`Claimed ${claims.length} tasks`);
-    return claims;
-  }
-
-  /**
-   * Return the queues that messages can be retrieved from.  Refresh the list
-   * of queues if the queue expiration is within the configured expiration window.
-   *
-   * @returns {Array} queues - List of queues that contains signed urls for retrieving
-   *                           and deleting messages
-   *
-   */
-  async getQueues() {
-    // If queue url expiration is within `expiration` then refresh the queues
-    // to reduce risk of using an expired url
-    let expiration = Date.now() + this.queueExpiration;
-    if (!this.queues || (expiration > new Date(this.queues.expires).getTime())) {
-      this.queues = await this.client.pollTaskUrls(this.provisionerId, this.workerType);
-    }
-    return this.queues;
-  }
-
-  /**
-   * Retrieves a particular number of tasks from a queue.
-   *
-   * @param {Object} queue - Queue object that contains signed urls
-   * @param {Number} numberOfTasks - The number of tasks that should be retrieved
-   */
-  async getTasksFromQueue(queue, numberOfTasks) {
-    let maxMessages = Math.min(numberOfTasks, MAX_MESSAGES_PER_REQUEST);
-    let tasks = [];
-    let uri = `${queue.signedPollUrl}&numofmessages=${maxMessages}`;
-
-    let response;
-    try {
-      response = await makeRequest(
-        'GET', uri, this.maxRetries, this.requestRetryInterval
-      );
-    }
-    catch (e) {
-      this.log('[alert operator] queue request error', {
-        message: 'Could not retrieve tasks from the queue',
-        err: e,
-        stack: e.stack
+    let result = await this.queue.claimWork(this.provisionerId, this.workerType, {
+      tasks:        Math.min(capacity, MAX_MESSAGES_PER_REQUEST),
+      workerGroup:  this.workerGroup,
+      workerId:     this.workerId,
+    });
+    result.tasks.forEach(claim => {
+      this.log('claimed task', {
+        taskId: claim.status.taskId,
+        runId:  claim.runId,
       });
-      return [];
-    }
-
-    let xml = await parseXmlString(response.text);
-
-    if(!xml.QueueMessagesList) return [];
-
-    for(let message of xml.QueueMessagesList.QueueMessage) {
-      let payload = new Buffer(message.MessageText[0], 'base64').toString();
-      payload = JSON.parse(payload);
-
-      // Construct a delete URL for each message based on the delete URL returned
-      // from polling for queue urls. Each URL is unique to each message in the queue
-      // based on message ID and pop Receipt.  This URL will be called when a
-      // message needs to be removed from the queue.
-      payload.deleteUri = queue.signedDeleteUrl
-       .replace('{{messageId}}', encodeURIComponent(message.MessageId[0]))
-       .replace('{{popReceipt}}', encodeURIComponent(message.PopReceipt[0]));
-
-      // If the message has been dequeued a lot, chances are the message is bad and should
-      // be removed from the queue and not claimed.
-      let dequeueCount = parseInt(message.DequeueCount[0]);
-      if (dequeueCount >= this.dequeueCount) {
-        this.log('[alert operator] task error', {
-          taskId: payload.taskId,
-          runId: payload.runId,
-          message: `Message has been dequeued ${dequeueCount} times.  Deleting from queue.`
-        });
-        await this.deleteTaskFromQueue(payload);
-        continue;
-      }
-
-      tasks.push(payload);
-    }
-    return tasks;
-  }
-
-  /**
-   * Deletes a specific task from the queue
-   *
-   * @param {Object} task - Task to remove from the queue
-   */
-  async deleteTaskFromQueue(task) {
-    try {
-      await makeRequest(
-        'DELETE', task.deleteUri, this.maxRetries, this.requestRetryInterval
-      );
-    }
-    catch (e) {
-      // Deleting from the queue should not cause a task not to be handled. Log
-      // error and continue
-      this.log('[alert operator] queue request error', {
-        taskId: task.taskId,
-        runId: task.runId,
-        message: 'Could not delete the task from the queue.',
-        err: e,
-        stack: e.stack
-      });
-    }
+    });
+    return result.tasks;
   }
 }

--- a/lib/queueservice.js
+++ b/lib/queueservice.js
@@ -55,14 +55,17 @@ export default class TaskQueue {
   async claimWork(capacity) {
     debug(`polling for ${capacity} tasks`);
     let result = await this.queue.claimWork(this.provisionerId, this.workerType, {
-      tasks:        Math.min(capacity, MAX_MESSAGES_PER_REQUEST),
-      workerGroup:  this.workerGroup,
-      workerId:     this.workerId,
+      tasks: Math.min(capacity, MAX_MESSAGES_PER_REQUEST),
+      workerGroup: this.workerGroup,
+      workerId: this.workerId
     });
+
+    debug(`claimed ${result.tasks.length} tasks`);
+
     result.tasks.forEach(claim => {
       this.log('claimed task', {
         taskId: claim.status.taskId,
-        runId:  claim.runId,
+        runId: claim.runId
       });
     });
     return result.tasks;

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3,53 +3,78 @@
   "version": "0.0.0",
   "dependencies": {
     "aws-sdk": {
-      "version": "2.5.5",
-      "from": "aws-sdk@2.5.5",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.5.5.tgz",
+      "version": "2.6.6",
+      "from": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.6.6.tgz",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.6.6.tgz",
       "dependencies": {
+        "buffer": {
+          "version": "4.9.1",
+          "from": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+          "dependencies": {
+            "base64-js": {
+              "version": "1.2.0",
+              "from": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.0.tgz",
+              "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.0.tgz"
+            },
+            "ieee754": {
+              "version": "1.1.8",
+              "from": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
+              "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz"
+            },
+            "isarray": {
+              "version": "1.0.0",
+              "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+            }
+          }
+        },
+        "crypto-browserify": {
+          "version": "1.0.9",
+          "from": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-1.0.9.tgz",
+          "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-1.0.9.tgz"
+        },
+        "jmespath": {
+          "version": "0.15.0",
+          "from": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
+          "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz"
+        },
+        "querystring": {
+          "version": "0.2.0",
+          "from": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz"
+        },
         "sax": {
           "version": "1.1.5",
-          "from": "sax@1.1.5",
+          "from": "https://registry.npmjs.org/sax/-/sax-1.1.5.tgz",
           "resolved": "https://registry.npmjs.org/sax/-/sax-1.1.5.tgz"
+        },
+        "url": {
+          "version": "0.10.3",
+          "from": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+          "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+          "dependencies": {
+            "punycode": {
+              "version": "1.3.2",
+              "from": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+              "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
+            }
+          }
         },
         "xml2js": {
           "version": "0.4.15",
-          "from": "xml2js@0.4.15",
+          "from": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.15.tgz",
           "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.15.tgz"
         },
         "xmlbuilder": {
           "version": "2.6.2",
-          "from": "xmlbuilder@2.6.2",
+          "from": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-2.6.2.tgz",
           "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-2.6.2.tgz",
           "dependencies": {
             "lodash": {
               "version": "3.5.0",
-              "from": "lodash@>=3.5.0 <3.6.0",
+              "from": "https://registry.npmjs.org/lodash/-/lodash-3.5.0.tgz",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.5.0.tgz"
-            }
-          }
-        },
-        "jmespath": {
-          "version": "0.15.0",
-          "from": "jmespath@0.15.0",
-          "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz"
-        }
-      }
-    },
-    "aws-sdk-promise": {
-      "version": "0.0.2",
-      "from": "https://registry.npmjs.org/aws-sdk-promise/-/aws-sdk-promise-0.0.2.tgz",
-      "resolved": "https://registry.npmjs.org/aws-sdk-promise/-/aws-sdk-promise-0.0.2.tgz",
-      "dependencies": {
-        "promise": {
-          "version": "6.1.0",
-          "from": "https://registry.npmjs.org/promise/-/promise-6.1.0.tgz",
-          "resolved": "https://registry.npmjs.org/promise/-/promise-6.1.0.tgz",
-          "dependencies": {
-            "asap": {
-              "version": "1.0.0",
-              "from": "https://registry.npmjs.org/asap/-/asap-1.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/asap/-/asap-1.0.0.tgz"
             }
           }
         }
@@ -333,9 +358,9 @@
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "inherits": {
-                      "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                      "version": "2.0.3",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                     }
                   }
                 }
@@ -401,14 +426,14 @@
           "resolved": "https://registry.npmjs.org/is-integer/-/is-integer-1.0.6.tgz",
           "dependencies": {
             "is-finite": {
-              "version": "1.0.1",
-              "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+              "version": "1.0.2",
+              "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+              "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
               "dependencies": {
                 "number-is-nan": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
                 }
               }
             }
@@ -437,21 +462,26 @@
           }
         },
         "output-file-sync": {
-          "version": "1.1.1",
-          "from": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.1.tgz",
-          "resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.1.tgz",
+          "version": "1.1.2",
+          "from": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.2.tgz",
           "dependencies": {
-            "xtend": {
-              "version": "4.0.1",
-              "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+            "graceful-fs": {
+              "version": "4.1.9",
+              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz"
+            },
+            "object-assign": {
+              "version": "4.1.0",
+              "from": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
+              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
             }
           }
         },
         "path-is-absolute": {
-          "version": "1.0.0",
-          "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+          "version": "1.0.1",
+          "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
         },
         "private": {
           "version": "0.1.6",
@@ -491,36 +521,36 @@
                   "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
                   "dependencies": {
                     "inflight": {
-                      "version": "1.0.4",
-                      "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                      "version": "1.0.5",
+                      "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
+                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
                       "dependencies": {
                         "wrappy": {
-                          "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                          "version": "1.0.2",
+                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                         }
                       }
                     },
                     "inherits": {
-                      "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                      "version": "2.0.3",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                     },
                     "minimatch": {
-                      "version": "3.0.0",
-                      "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                      "version": "3.0.3",
+                      "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
                       "dependencies": {
                         "brace-expansion": {
-                          "version": "1.1.4",
-                          "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.4.tgz",
-                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.4.tgz",
+                          "version": "1.1.6",
+                          "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
+                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
                           "dependencies": {
                             "balanced-match": {
-                              "version": "0.4.1",
-                              "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.1.tgz",
-                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.1.tgz"
+                              "version": "0.4.2",
+                              "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
                             },
                             "concat-map": {
                               "version": "0.0.1",
@@ -532,23 +562,23 @@
                       }
                     },
                     "once": {
-                      "version": "1.3.3",
-                      "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                      "version": "1.4.0",
+                      "from": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+                      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
                       "dependencies": {
                         "wrappy": {
-                          "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                          "version": "1.0.2",
+                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                         }
                       }
                     }
                   }
                 },
                 "graceful-fs": {
-                  "version": "4.1.3",
-                  "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz",
-                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
+                  "version": "4.1.9",
+                  "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
+                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz"
                 },
                 "iconv-lite": {
                   "version": "0.4.13",
@@ -597,9 +627,9 @@
           "resolved": "https://registry.npmjs.org/regexpu/-/regexpu-1.3.0.tgz",
           "dependencies": {
             "esprima": {
-              "version": "2.7.2",
-              "from": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz",
-              "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz"
+              "version": "2.7.3",
+              "from": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+              "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz"
             },
             "recast": {
               "version": "0.10.43",
@@ -624,9 +654,9 @@
               }
             },
             "regenerate": {
-              "version": "1.2.1",
-              "from": "https://registry.npmjs.org/regenerate/-/regenerate-1.2.1.tgz",
-              "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.2.1.tgz"
+              "version": "1.3.1",
+              "from": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.1.tgz",
+              "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.1.tgz"
             },
             "regjsgen": {
               "version": "0.2.0",
@@ -653,14 +683,14 @@
           "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
           "dependencies": {
             "is-finite": {
-              "version": "1.0.1",
-              "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+              "version": "1.0.2",
+              "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+              "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
               "dependencies": {
                 "number-is-nan": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
                 }
               }
             }
@@ -730,9 +760,9 @@
           "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
         },
         "es5-ext": {
-          "version": "0.10.11",
-          "from": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.11.tgz",
-          "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.11.tgz",
+          "version": "0.10.12",
+          "from": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.12.tgz",
+          "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.12.tgz",
           "dependencies": {
             "es6-iterator": {
               "version": "2.0.0",
@@ -740,9 +770,9 @@
               "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz"
             },
             "es6-symbol": {
-              "version": "3.0.2",
-              "from": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.0.2.tgz",
-              "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.0.2.tgz"
+              "version": "3.1.0",
+              "from": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.0.tgz",
+              "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.0.tgz"
             }
           }
         },
@@ -863,9 +893,9 @@
       }
     },
     "docker-exec-websocket-server": {
-      "version": "1.2.0",
-      "from": "https://registry.npmjs.org/docker-exec-websocket-server/-/docker-exec-websocket-server-1.2.0.tgz",
-      "resolved": "https://registry.npmjs.org/docker-exec-websocket-server/-/docker-exec-websocket-server-1.2.0.tgz",
+      "version": "1.3.1",
+      "from": "https://registry.npmjs.org/docker-exec-websocket-server/-/docker-exec-websocket-server-1.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/docker-exec-websocket-server/-/docker-exec-websocket-server-1.3.1.tgz",
       "dependencies": {
         "babel-runtime": {
           "version": "5.8.38",
@@ -873,9 +903,9 @@
           "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.38.tgz",
           "dependencies": {
             "core-js": {
-              "version": "1.2.6",
-              "from": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz",
-              "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
+              "version": "1.2.7",
+              "from": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+              "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz"
             }
           }
         },
@@ -949,9 +979,9 @@
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "inherits": {
-                      "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                      "version": "2.0.3",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                     }
                   }
                 },
@@ -1004,9 +1034,9 @@
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                 },
                 "inherits": {
-                  "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                  "version": "2.0.3",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                 },
                 "isarray": {
                   "version": "1.0.0",
@@ -1014,9 +1044,9 @@
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                 },
                 "process-nextick-args": {
-                  "version": "1.0.6",
-                  "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
-                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
+                  "version": "1.0.7",
+                  "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
@@ -1038,9 +1068,9 @@
           }
         },
         "ws": {
-          "version": "1.0.1",
-          "from": "https://registry.npmjs.org/ws/-/ws-1.0.1.tgz",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-1.0.1.tgz",
+          "version": "1.1.1",
+          "from": "https://registry.npmjs.org/ws/-/ws-1.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.1.tgz",
           "dependencies": {
             "options": {
               "version": "0.0.6",
@@ -1067,14 +1097,14 @@
       "resolved": "https://registry.npmjs.org/docker-image-parser/-/docker-image-parser-1.0.0.tgz"
     },
     "dockerode": {
-      "version": "2.2.10",
-      "from": "https://registry.npmjs.org/dockerode/-/dockerode-2.2.10.tgz",
-      "resolved": "https://registry.npmjs.org/dockerode/-/dockerode-2.2.10.tgz",
+      "version": "2.3.1",
+      "from": "https://registry.npmjs.org/dockerode/-/dockerode-2.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/dockerode/-/dockerode-2.3.1.tgz",
       "dependencies": {
         "docker-modem": {
-          "version": "0.3.0",
-          "from": "https://registry.npmjs.org/docker-modem/-/docker-modem-0.3.0.tgz",
-          "resolved": "https://registry.npmjs.org/docker-modem/-/docker-modem-0.3.0.tgz",
+          "version": "0.3.1",
+          "from": "https://registry.npmjs.org/docker-modem/-/docker-modem-0.3.1.tgz",
+          "resolved": "https://registry.npmjs.org/docker-modem/-/docker-modem-0.3.1.tgz",
           "dependencies": {
             "JSONStream": {
               "version": "0.10.0",
@@ -1131,9 +1161,9 @@
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "inherits": {
-                  "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                  "version": "2.0.3",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                 }
               }
             },
@@ -1162,9 +1192,9 @@
           "resolved": "https://registry.npmjs.org/promise/-/promise-7.0.4.tgz",
           "dependencies": {
             "asap": {
-              "version": "2.0.3",
-              "from": "https://registry.npmjs.org/asap/-/asap-2.0.3.tgz",
-              "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.3.tgz"
+              "version": "2.0.5",
+              "from": "https://registry.npmjs.org/asap/-/asap-2.0.5.tgz",
+              "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.5.tgz"
             }
           }
         },
@@ -1181,31 +1211,31 @@
       "resolved": "https://registry.npmjs.org/dockerode-promise/-/dockerode-promise-0.1.0.tgz"
     },
     "express": {
-      "version": "4.13.4",
-      "from": "https://registry.npmjs.org/express/-/express-4.13.4.tgz",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.13.4.tgz",
+      "version": "4.14.0",
+      "from": "https://registry.npmjs.org/express/-/express-4.14.0.tgz",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.14.0.tgz",
       "dependencies": {
         "accepts": {
-          "version": "1.2.13",
-          "from": "https://registry.npmjs.org/accepts/-/accepts-1.2.13.tgz",
-          "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.2.13.tgz",
+          "version": "1.3.3",
+          "from": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
+          "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
           "dependencies": {
             "mime-types": {
-              "version": "2.1.11",
-              "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz",
-              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz",
+              "version": "2.1.12",
+              "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
               "dependencies": {
                 "mime-db": {
-                  "version": "1.23.0",
-                  "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz",
-                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz"
+                  "version": "1.24.0",
+                  "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz",
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz"
                 }
               }
             },
             "negotiator": {
-              "version": "0.5.3",
-              "from": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.3.tgz",
-              "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.3.tgz"
+              "version": "0.6.1",
+              "from": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
+              "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz"
             }
           }
         },
@@ -1220,14 +1250,14 @@
           "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.1.tgz"
         },
         "content-type": {
-          "version": "1.0.1",
-          "from": "https://registry.npmjs.org/content-type/-/content-type-1.0.1.tgz",
-          "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.1.tgz"
+          "version": "1.0.2",
+          "from": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz"
         },
         "cookie": {
-          "version": "0.1.5",
-          "from": "https://registry.npmjs.org/cookie/-/cookie-0.1.5.tgz",
-          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.5.tgz"
+          "version": "0.3.1",
+          "from": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz"
         },
         "cookie-signature": {
           "version": "1.0.6",
@@ -1238,6 +1268,11 @@
           "version": "1.1.0",
           "from": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz",
           "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz"
+        },
+        "encodeurl": {
+          "version": "1.0.1",
+          "from": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz"
         },
         "escape-html": {
           "version": "1.0.3",
@@ -1250,10 +1285,15 @@
           "resolved": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz"
         },
         "finalhandler": {
-          "version": "0.4.1",
-          "from": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.4.1.tgz",
-          "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.4.1.tgz",
+          "version": "0.5.0",
+          "from": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.5.0.tgz",
+          "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.5.0.tgz",
           "dependencies": {
+            "statuses": {
+              "version": "1.3.0",
+              "from": "https://registry.npmjs.org/statuses/-/statuses-1.3.0.tgz",
+              "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.0.tgz"
+            },
             "unpipe": {
               "version": "1.0.0",
               "from": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -1299,9 +1339,9 @@
           "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz"
         },
         "proxy-addr": {
-          "version": "1.0.10",
-          "from": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.0.10.tgz",
-          "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.0.10.tgz",
+          "version": "1.1.2",
+          "from": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.2.tgz",
           "dependencies": {
             "forwarded": {
               "version": "0.1.0",
@@ -1309,26 +1349,26 @@
               "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz"
             },
             "ipaddr.js": {
-              "version": "1.0.5",
-              "from": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.0.5.tgz",
-              "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.0.5.tgz"
+              "version": "1.1.1",
+              "from": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.1.1.tgz",
+              "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.1.1.tgz"
             }
           }
         },
         "qs": {
-          "version": "4.0.0",
-          "from": "https://registry.npmjs.org/qs/-/qs-4.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-4.0.0.tgz"
+          "version": "6.2.0",
+          "from": "https://registry.npmjs.org/qs/-/qs-6.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.0.tgz"
         },
         "range-parser": {
-          "version": "1.0.3",
-          "from": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.3.tgz",
-          "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.3.tgz"
+          "version": "1.2.0",
+          "from": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz"
         },
         "send": {
-          "version": "0.13.1",
-          "from": "https://registry.npmjs.org/send/-/send-0.13.1.tgz",
-          "resolved": "https://registry.npmjs.org/send/-/send-0.13.1.tgz",
+          "version": "0.14.1",
+          "from": "https://registry.npmjs.org/send/-/send-0.14.1.tgz",
+          "resolved": "https://registry.npmjs.org/send/-/send-0.14.1.tgz",
           "dependencies": {
             "destroy": {
               "version": "1.0.4",
@@ -1336,14 +1376,19 @@
               "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz"
             },
             "http-errors": {
-              "version": "1.3.1",
-              "from": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
-              "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
+              "version": "1.5.0",
+              "from": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.0.tgz",
+              "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.0.tgz",
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
                   "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "setprototypeof": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.1.tgz"
                 }
               }
             },
@@ -1353,21 +1398,21 @@
               "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
             },
             "statuses": {
-              "version": "1.2.1",
-              "from": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz",
-              "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz"
+              "version": "1.3.0",
+              "from": "https://registry.npmjs.org/statuses/-/statuses-1.3.0.tgz",
+              "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.0.tgz"
             }
           }
         },
         "serve-static": {
-          "version": "1.10.2",
-          "from": "https://registry.npmjs.org/serve-static/-/serve-static-1.10.2.tgz",
-          "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.10.2.tgz"
+          "version": "1.11.1",
+          "from": "https://registry.npmjs.org/serve-static/-/serve-static-1.11.1.tgz",
+          "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.11.1.tgz"
         },
         "type-is": {
-          "version": "1.6.12",
-          "from": "https://registry.npmjs.org/type-is/-/type-is-1.6.12.tgz",
-          "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.12.tgz",
+          "version": "1.6.13",
+          "from": "https://registry.npmjs.org/type-is/-/type-is-1.6.13.tgz",
+          "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.13.tgz",
           "dependencies": {
             "media-typer": {
               "version": "0.3.0",
@@ -1375,14 +1420,14 @@
               "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
             },
             "mime-types": {
-              "version": "2.1.11",
-              "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz",
-              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz",
+              "version": "2.1.12",
+              "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
               "dependencies": {
                 "mime-db": {
-                  "version": "1.23.0",
-                  "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz",
-                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz"
+                  "version": "1.24.0",
+                  "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz",
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz"
                 }
               }
             }
@@ -1394,9 +1439,9 @@
           "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
         },
         "vary": {
-          "version": "1.0.1",
-          "from": "https://registry.npmjs.org/vary/-/vary-1.0.1.tgz",
-          "resolved": "https://registry.npmjs.org/vary/-/vary-1.0.1.tgz"
+          "version": "1.1.0",
+          "from": "https://registry.npmjs.org/vary/-/vary-1.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.0.tgz"
         }
       }
     },
@@ -1445,9 +1490,9 @@
           "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz"
         },
         "is-retry-allowed": {
-          "version": "1.0.0",
-          "from": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.0.0.tgz"
+          "version": "1.1.0",
+          "from": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz"
         },
         "is-stream": {
           "version": "1.1.0",
@@ -1506,19 +1551,24 @@
           "resolved": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-3.1.0.tgz"
         },
         "readable-stream": {
-          "version": "2.1.2",
-          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.2.tgz",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.2.tgz",
+          "version": "2.1.5",
+          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
           "dependencies": {
+            "buffer-shims": {
+              "version": "1.0.0",
+              "from": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
+            },
             "core-util-is": {
               "version": "1.0.2",
               "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
               "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
             },
             "inherits": {
-              "version": "2.0.1",
-              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+              "version": "2.0.3",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
             },
             "isarray": {
               "version": "1.0.0",
@@ -1526,9 +1576,9 @@
               "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
             },
             "process-nextick-args": {
-              "version": "1.0.6",
-              "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
-              "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
+              "version": "1.0.7",
+              "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+              "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
             },
             "string_decoder": {
               "version": "0.10.31",
@@ -1548,9 +1598,9 @@
           "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-2.0.0.tgz"
         },
         "unzip-response": {
-          "version": "1.0.0",
-          "from": "https://registry.npmjs.org/unzip-response/-/unzip-response-1.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-1.0.0.tgz"
+          "version": "1.0.1",
+          "from": "https://registry.npmjs.org/unzip-response/-/unzip-response-1.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-1.0.1.tgz"
         },
         "url-parse-lax": {
           "version": "1.0.0",
@@ -1558,18 +1608,18 @@
           "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
           "dependencies": {
             "prepend-http": {
-              "version": "1.0.3",
-              "from": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.3.tgz",
-              "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.3.tgz"
+              "version": "1.0.4",
+              "from": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+              "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz"
             }
           }
         }
       }
     },
     "http-proxy": {
-      "version": "1.13.2",
-      "from": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.13.2.tgz",
-      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.13.2.tgz",
+      "version": "1.15.1",
+      "from": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.15.1.tgz",
+      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.15.1.tgz",
       "dependencies": {
         "eventemitter3": {
           "version": "1.2.0",
@@ -1596,9 +1646,9 @@
       }
     },
     "json-templater": {
-      "version": "1.0.2",
-      "from": "https://registry.npmjs.org/json-templater/-/json-templater-1.0.2.tgz",
-      "resolved": "https://registry.npmjs.org/json-templater/-/json-templater-1.0.2.tgz"
+      "version": "1.0.4",
+      "from": "https://registry.npmjs.org/json-templater/-/json-templater-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/json-templater/-/json-templater-1.0.4.tgz"
     },
     "koa": {
       "version": "0.19.1",
@@ -1606,14 +1656,14 @@
       "resolved": "https://registry.npmjs.org/koa/-/koa-0.19.1.tgz",
       "dependencies": {
         "accepts": {
-          "version": "1.3.2",
-          "from": "https://registry.npmjs.org/accepts/-/accepts-1.3.2.tgz",
-          "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.2.tgz",
+          "version": "1.3.3",
+          "from": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
+          "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
           "dependencies": {
             "negotiator": {
-              "version": "0.6.0",
-              "from": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.0.tgz",
-              "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.0.tgz"
+              "version": "0.6.1",
+              "from": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
+              "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz"
             }
           }
         },
@@ -1628,9 +1678,9 @@
           "resolved": "https://registry.npmjs.org/composition/-/composition-2.3.0.tgz",
           "dependencies": {
             "any-promise": {
-              "version": "1.1.0",
-              "from": "https://registry.npmjs.org/any-promise/-/any-promise-1.1.0.tgz",
-              "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.1.0.tgz"
+              "version": "1.3.0",
+              "from": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+              "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz"
             }
           }
         },
@@ -1640,9 +1690,9 @@
           "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.1.tgz"
         },
         "content-type": {
-          "version": "1.0.1",
-          "from": "https://registry.npmjs.org/content-type/-/content-type-1.0.1.tgz",
-          "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.1.tgz"
+          "version": "1.0.2",
+          "from": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz"
         },
         "cookies": {
           "version": "0.5.1",
@@ -1690,18 +1740,35 @@
               "version": "1.0.1",
               "from": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz"
+            },
+            "http-errors": {
+              "version": "1.4.0",
+              "from": "https://registry.npmjs.org/http-errors/-/http-errors-1.4.0.tgz",
+              "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.4.0.tgz",
+              "dependencies": {
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
             }
           }
         },
         "http-errors": {
-          "version": "1.4.0",
-          "from": "https://registry.npmjs.org/http-errors/-/http-errors-1.4.0.tgz",
-          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.4.0.tgz",
+          "version": "1.5.0",
+          "from": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.0.tgz",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.0.tgz",
           "dependencies": {
             "inherits": {
               "version": "2.0.1",
               "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+            },
+            "setprototypeof": {
+              "version": "1.0.1",
+              "from": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.1.tgz"
             }
           }
         },
@@ -1716,14 +1783,14 @@
           "resolved": "https://registry.npmjs.org/koa-is-json/-/koa-is-json-1.0.0.tgz"
         },
         "mime-types": {
-          "version": "2.1.11",
-          "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz",
+          "version": "2.1.12",
+          "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
           "dependencies": {
             "mime-db": {
-              "version": "1.23.0",
-              "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz",
-              "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz"
+              "version": "1.24.0",
+              "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz",
+              "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz"
             }
           }
         },
@@ -1750,14 +1817,14 @@
           "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz"
         },
         "statuses": {
-          "version": "1.2.1",
-          "from": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz",
-          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz"
+          "version": "1.3.0",
+          "from": "https://registry.npmjs.org/statuses/-/statuses-1.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.0.tgz"
         },
         "type-is": {
-          "version": "1.6.12",
-          "from": "https://registry.npmjs.org/type-is/-/type-is-1.6.12.tgz",
-          "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.12.tgz",
+          "version": "1.6.13",
+          "from": "https://registry.npmjs.org/type-is/-/type-is-1.6.13.tgz",
+          "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.13.tgz",
           "dependencies": {
             "media-typer": {
               "version": "0.3.0",
@@ -1794,19 +1861,24 @@
               "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
             },
             "readable-stream": {
-              "version": "2.1.2",
-              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.2.tgz",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.2.tgz",
+              "version": "2.1.5",
+              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
               "dependencies": {
+                "buffer-shims": {
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
+                },
                 "core-util-is": {
                   "version": "1.0.2",
                   "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                 },
                 "inherits": {
-                  "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                  "version": "2.0.3",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                 },
                 "isarray": {
                   "version": "1.0.0",
@@ -1814,9 +1886,9 @@
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                 },
                 "process-nextick-args": {
-                  "version": "1.0.6",
-                  "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
-                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
+                  "version": "1.0.7",
+                  "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
@@ -1845,19 +1917,24 @@
           "resolved": "https://registry.npmjs.org/concat-regexp/-/concat-regexp-0.0.6.tgz"
         },
         "http-errors": {
-          "version": "1.4.0",
-          "from": "https://registry.npmjs.org/http-errors/-/http-errors-1.4.0.tgz",
-          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.4.0.tgz",
+          "version": "1.5.0",
+          "from": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.0.tgz",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.0.tgz",
           "dependencies": {
             "inherits": {
               "version": "2.0.1",
               "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
+            "setprototypeof": {
+              "version": "1.0.1",
+              "from": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.1.tgz"
+            },
             "statuses": {
-              "version": "1.2.1",
-              "from": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz",
-              "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz"
+              "version": "1.3.0",
+              "from": "https://registry.npmjs.org/statuses/-/statuses-1.3.0.tgz",
+              "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.0.tgz"
             }
           }
         },
@@ -1872,9 +1949,9 @@
           "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz"
         },
         "path-to-regexp": {
-          "version": "1.2.1",
-          "from": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.2.1.tgz",
-          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.2.1.tgz",
+          "version": "1.6.0",
+          "from": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.6.0.tgz",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.6.0.tgz",
           "dependencies": {
             "isarray": {
               "version": "0.0.1",
@@ -1916,9 +1993,9 @@
               "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
             },
             "inherits": {
-              "version": "2.0.1",
-              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+              "version": "2.0.3",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
             }
           }
         }
@@ -1961,9 +2038,9 @@
       }
     },
     "mocha": {
-      "version": "2.4.5",
-      "from": "https://registry.npmjs.org/mocha/-/mocha-2.4.5.tgz",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-2.4.5.tgz",
+      "version": "2.5.3",
+      "from": "https://registry.npmjs.org/mocha/-/mocha-2.5.3.tgz",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-2.5.3.tgz",
       "dependencies": {
         "commander": {
           "version": "2.3.0",
@@ -1981,14 +2058,19 @@
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
         },
         "glob": {
-          "version": "3.2.3",
-          "from": "https://registry.npmjs.org/glob/-/glob-3.2.3.tgz",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.3.tgz",
+          "version": "3.2.11",
+          "from": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
           "dependencies": {
+            "inherits": {
+              "version": "2.0.3",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+            },
             "minimatch": {
-              "version": "0.2.14",
-              "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+              "version": "0.3.0",
+              "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
               "dependencies": {
                 "lru-cache": {
                   "version": "2.7.3",
@@ -2001,23 +2083,13 @@
                   "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                 }
               }
-            },
-            "graceful-fs": {
-              "version": "2.0.3",
-              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz",
-              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
-            },
-            "inherits": {
-              "version": "2.0.1",
-              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             }
           }
         },
         "growl": {
-          "version": "1.8.1",
-          "from": "https://registry.npmjs.org/growl/-/growl-1.8.1.tgz",
-          "resolved": "https://registry.npmjs.org/growl/-/growl-1.8.1.tgz"
+          "version": "1.9.2",
+          "from": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
+          "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz"
         },
         "jade": {
           "version": "0.26.3",
@@ -2040,6 +2112,11 @@
           "version": "1.2.0",
           "from": "https://registry.npmjs.org/supports-color/-/supports-color-1.2.0.tgz",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.2.0.tgz"
+        },
+        "to-iso-string": {
+          "version": "0.0.2",
+          "from": "https://registry.npmjs.org/to-iso-string/-/to-iso-string-0.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/to-iso-string/-/to-iso-string-0.0.2.tgz"
         }
       }
     },
@@ -2049,9 +2126,9 @@
       "resolved": "https://registry.npmjs.org/mz/-/mz-2.4.0.tgz",
       "dependencies": {
         "any-promise": {
-          "version": "1.1.0",
-          "from": "https://registry.npmjs.org/any-promise/-/any-promise-1.1.0.tgz",
-          "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.1.0.tgz"
+          "version": "1.3.0",
+          "from": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz"
         },
         "object-assign": {
           "version": "4.1.0",
@@ -2083,9 +2160,9 @@
           "resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
           "dependencies": {
             "assertion-error": {
-              "version": "1.0.1",
-              "from": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.1.tgz"
+              "version": "1.0.2",
+              "from": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
+              "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz"
             },
             "deep-eql": {
               "version": "0.1.3",
@@ -2129,14 +2206,14 @@
       }
     },
     "openpgp": {
-      "version": "2.3.2",
-      "from": "https://registry.npmjs.org/openpgp/-/openpgp-2.3.2.tgz",
-      "resolved": "https://registry.npmjs.org/openpgp/-/openpgp-2.3.2.tgz",
+      "version": "2.3.3",
+      "from": "https://registry.npmjs.org/openpgp/-/openpgp-2.3.3.tgz",
+      "resolved": "https://registry.npmjs.org/openpgp/-/openpgp-2.3.3.tgz",
       "dependencies": {
         "node-fetch": {
-          "version": "1.6.0",
-          "from": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.6.0.tgz",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.6.0.tgz",
+          "version": "1.6.3",
+          "from": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.6.3.tgz",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.6.3.tgz",
           "dependencies": {
             "encoding": {
               "version": "0.1.12",
@@ -2158,9 +2235,33 @@
           }
         },
         "node-localstorage": {
-          "version": "1.1.2",
-          "from": "https://registry.npmjs.org/node-localstorage/-/node-localstorage-1.1.2.tgz",
-          "resolved": "https://registry.npmjs.org/node-localstorage/-/node-localstorage-1.1.2.tgz"
+          "version": "1.3.0",
+          "from": "https://registry.npmjs.org/node-localstorage/-/node-localstorage-1.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/node-localstorage/-/node-localstorage-1.3.0.tgz",
+          "dependencies": {
+            "write-file-atomic": {
+              "version": "1.2.0",
+              "from": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.2.0.tgz",
+              "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.2.0.tgz",
+              "dependencies": {
+                "graceful-fs": {
+                  "version": "4.1.9",
+                  "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
+                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz"
+                },
+                "imurmurhash": {
+                  "version": "0.1.4",
+                  "from": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+                  "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz"
+                },
+                "slide": {
+                  "version": "1.1.6",
+                  "from": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+                  "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -2170,9 +2271,9 @@
       "resolved": "https://registry.npmjs.org/promise/-/promise-7.1.1.tgz",
       "dependencies": {
         "asap": {
-          "version": "2.0.3",
-          "from": "https://registry.npmjs.org/asap/-/asap-2.0.3.tgz",
-          "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.3.tgz"
+          "version": "2.0.5",
+          "from": "https://registry.npmjs.org/asap/-/asap-2.0.5.tgz",
+          "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.5.tgz"
         }
       }
     },
@@ -2182,9 +2283,9 @@
       "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-0.2.9.tgz",
       "dependencies": {
         "bluebird": {
-          "version": "2.10.2",
-          "from": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz"
+          "version": "2.11.0",
+          "from": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz"
         },
         "err-code": {
           "version": "0.1.2",
@@ -2216,9 +2317,9 @@
       "resolved": "https://registry.npmjs.org/readdirrsync/-/readdirrsync-0.0.3.tgz"
     },
     "request": {
-      "version": "2.72.0",
-      "from": "https://registry.npmjs.org/request/-/request-2.72.0.tgz",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.72.0.tgz",
+      "version": "2.75.0",
+      "from": "https://registry.npmjs.org/request/-/request-2.75.0.tgz",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.75.0.tgz",
       "dependencies": {
         "aws-sign2": {
           "version": "0.6.0",
@@ -2226,28 +2327,9 @@
           "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
         },
         "aws4": {
-          "version": "1.3.2",
-          "from": "https://registry.npmjs.org/aws4/-/aws4-1.3.2.tgz",
-          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.3.2.tgz",
-          "dependencies": {
-            "lru-cache": {
-              "version": "4.0.1",
-              "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.1.tgz",
-              "dependencies": {
-                "pseudomap": {
-                  "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz"
-                },
-                "yallist": {
-                  "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/yallist/-/yallist-2.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.0.0.tgz"
-                }
-              }
-            }
-          }
+          "version": "1.4.1",
+          "from": "https://registry.npmjs.org/aws4/-/aws4-1.4.1.tgz",
+          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.4.1.tgz"
         },
         "bl": {
           "version": "1.1.2",
@@ -2265,9 +2347,9 @@
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                 },
                 "inherits": {
-                  "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                  "version": "2.0.3",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                 },
                 "isarray": {
                   "version": "1.0.0",
@@ -2275,9 +2357,9 @@
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                 },
                 "process-nextick-args": {
-                  "version": "1.0.6",
-                  "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
-                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
+                  "version": "1.0.7",
+                  "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
@@ -2321,14 +2403,14 @@
           "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
         },
         "form-data": {
-          "version": "1.0.0-rc4",
-          "from": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc4.tgz",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc4.tgz",
+          "version": "2.0.0",
+          "from": "https://registry.npmjs.org/form-data/-/form-data-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.0.0.tgz",
           "dependencies": {
-            "async": {
-              "version": "1.5.2",
-              "from": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-              "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
+            "asynckit": {
+              "version": "0.4.0",
+              "from": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+              "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz"
             }
           }
         },
@@ -2384,9 +2466,9 @@
               }
             },
             "is-my-json-valid": {
-              "version": "2.13.1",
-              "from": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.13.1.tgz",
-              "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.13.1.tgz",
+              "version": "2.15.0",
+              "from": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.15.0.tgz",
+              "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.15.0.tgz",
               "dependencies": {
                 "generate-function": {
                   "version": "2.0.0",
@@ -2406,9 +2488,9 @@
                   }
                 },
                 "jsonpointer": {
-                  "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
+                  "version": "4.0.0",
+                  "from": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.0.tgz"
                 },
                 "xtend": {
                   "version": "4.0.1",
@@ -2469,9 +2551,9 @@
               "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
             },
             "jsprim": {
-              "version": "1.2.2",
-              "from": "https://registry.npmjs.org/jsprim/-/jsprim-1.2.2.tgz",
-              "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.2.2.tgz",
+              "version": "1.3.1",
+              "from": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.1.tgz",
+              "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.1.tgz",
               "dependencies": {
                 "extsprintf": {
                   "version": "1.0.2",
@@ -2479,9 +2561,9 @@
                   "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
                 },
                 "json-schema": {
-                  "version": "0.2.2",
-                  "from": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz",
-                  "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz"
+                  "version": "0.2.3",
+                  "from": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+                  "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz"
                 },
                 "verror": {
                   "version": "1.3.6",
@@ -2491,9 +2573,9 @@
               }
             },
             "sshpk": {
-              "version": "1.8.3",
-              "from": "https://registry.npmjs.org/sshpk/-/sshpk-1.8.3.tgz",
-              "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.8.3.tgz",
+              "version": "1.10.1",
+              "from": "https://registry.npmjs.org/sshpk/-/sshpk-1.10.1.tgz",
+              "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.10.1.tgz",
               "dependencies": {
                 "asn1": {
                   "version": "0.2.3",
@@ -2506,9 +2588,9 @@
                   "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
                 },
                 "dashdash": {
-                  "version": "1.13.1",
-                  "from": "https://registry.npmjs.org/dashdash/-/dashdash-1.13.1.tgz",
-                  "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.13.1.tgz"
+                  "version": "1.14.0",
+                  "from": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.0.tgz",
+                  "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.0.tgz"
                 },
                 "getpass": {
                   "version": "0.1.6",
@@ -2521,9 +2603,9 @@
                   "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
                 },
                 "tweetnacl": {
-                  "version": "0.13.3",
-                  "from": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.3.tgz",
-                  "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.3.tgz"
+                  "version": "0.14.3",
+                  "from": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.3.tgz",
+                  "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.3.tgz"
                 },
                 "jodid25519": {
                   "version": "1.0.2",
@@ -2534,6 +2616,11 @@
                   "version": "0.1.1",
                   "from": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
+                },
+                "bcrypt-pbkdf": {
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.0.tgz"
                 }
               }
             }
@@ -2555,14 +2642,14 @@
           "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
         },
         "mime-types": {
-          "version": "2.1.11",
-          "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz",
+          "version": "2.1.12",
+          "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
           "dependencies": {
             "mime-db": {
-              "version": "1.23.0",
-              "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz",
-              "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz"
+              "version": "1.24.0",
+              "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz",
+              "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz"
             }
           }
         },
@@ -2572,14 +2659,14 @@
           "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
         },
         "oauth-sign": {
-          "version": "0.8.1",
-          "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.1.tgz",
-          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.1.tgz"
+          "version": "0.8.2",
+          "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz"
         },
         "qs": {
-          "version": "6.1.0",
-          "from": "https://registry.npmjs.org/qs/-/qs-6.1.0.tgz",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.1.0.tgz"
+          "version": "6.2.1",
+          "from": "https://registry.npmjs.org/qs/-/qs-6.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.1.tgz"
         },
         "stringstream": {
           "version": "0.0.5",
@@ -2587,58 +2674,63 @@
           "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
         },
         "tough-cookie": {
-          "version": "2.2.2",
-          "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.2.tgz",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.2.tgz"
+          "version": "2.3.1",
+          "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.1.tgz",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.1.tgz"
         },
         "tunnel-agent": {
-          "version": "0.4.2",
-          "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz",
-          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz"
+          "version": "0.4.3",
+          "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz"
         }
       }
     },
     "rimraf": {
-      "version": "2.5.2",
-      "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
+      "version": "2.5.4",
+      "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
       "dependencies": {
         "glob": {
-          "version": "7.0.3",
-          "from": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
+          "version": "7.1.0",
+          "from": "https://registry.npmjs.org/glob/-/glob-7.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.0.tgz",
           "dependencies": {
+            "fs.realpath": {
+              "version": "1.0.0",
+              "from": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
+            },
             "inflight": {
-              "version": "1.0.4",
-              "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+              "version": "1.0.5",
+              "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
+              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
               "dependencies": {
                 "wrappy": {
-                  "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                  "version": "1.0.2",
+                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                 }
               }
             },
             "inherits": {
-              "version": "2.0.1",
-              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+              "version": "2.0.3",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
             },
             "minimatch": {
-              "version": "3.0.0",
-              "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+              "version": "3.0.3",
+              "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
               "dependencies": {
                 "brace-expansion": {
-                  "version": "1.1.4",
-                  "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.4.tgz",
-                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.4.tgz",
+                  "version": "1.1.6",
+                  "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
+                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
                   "dependencies": {
                     "balanced-match": {
-                      "version": "0.4.1",
-                      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.1.tgz",
-                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.1.tgz"
+                      "version": "0.4.2",
+                      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
                     },
                     "concat-map": {
                       "version": "0.0.1",
@@ -2650,21 +2742,21 @@
               }
             },
             "once": {
-              "version": "1.3.3",
-              "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-              "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+              "version": "1.4.0",
+              "from": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+              "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
               "dependencies": {
                 "wrappy": {
-                  "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                  "version": "1.0.2",
+                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                 }
               }
             },
             "path-is-absolute": {
-              "version": "1.0.0",
-              "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+              "version": "1.0.1",
+              "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
             }
           }
         }
@@ -2676,9 +2768,9 @@
       "resolved": "https://registry.npmjs.org/slugid/-/slugid-1.1.0.tgz",
       "dependencies": {
         "uuid": {
-          "version": "2.0.2",
-          "from": "https://registry.npmjs.org/uuid/-/uuid-2.0.2.tgz",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.2.tgz"
+          "version": "2.0.3",
+          "from": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz"
         }
       }
     },
@@ -2713,9 +2805,9 @@
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "inherits": {
-                  "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                  "version": "2.0.3",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                 }
               }
             },
@@ -2773,19 +2865,24 @@
                   "resolved": "https://registry.npmjs.org/buffercursor/-/buffercursor-0.0.12.tgz",
                   "dependencies": {
                     "verror": {
-                      "version": "1.6.1",
-                      "from": "https://registry.npmjs.org/verror/-/verror-1.6.1.tgz",
-                      "resolved": "https://registry.npmjs.org/verror/-/verror-1.6.1.tgz",
+                      "version": "1.8.1",
+                      "from": "https://registry.npmjs.org/verror/-/verror-1.8.1.tgz",
+                      "resolved": "https://registry.npmjs.org/verror/-/verror-1.8.1.tgz",
                       "dependencies": {
+                        "assert-plus": {
+                          "version": "1.0.0",
+                          "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+                        },
                         "core-util-is": {
                           "version": "1.0.2",
                           "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                         },
                         "extsprintf": {
-                          "version": "1.2.0",
-                          "from": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.2.0.tgz",
-                          "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.2.0.tgz"
+                          "version": "1.3.0",
+                          "from": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+                          "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz"
                         }
                       }
                     }
@@ -2830,9 +2927,9 @@
       "resolved": "https://registry.npmjs.org/statsd-client/-/statsd-client-0.0.15.tgz"
     },
     "superagent": {
-      "version": "1.8.3",
-      "from": "https://registry.npmjs.org/superagent/-/superagent-1.8.3.tgz",
-      "resolved": "https://registry.npmjs.org/superagent/-/superagent-1.8.3.tgz",
+      "version": "1.8.4",
+      "from": "https://registry.npmjs.org/superagent/-/superagent-1.8.4.tgz",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-1.8.4.tgz",
       "dependencies": {
         "qs": {
           "version": "2.3.3",
@@ -2892,14 +2989,14 @@
               }
             },
             "mime-types": {
-              "version": "2.1.11",
-              "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz",
-              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz",
+              "version": "2.1.12",
+              "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
               "dependencies": {
                 "mime-db": {
-                  "version": "1.23.0",
-                  "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz",
-                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz"
+                  "version": "1.24.0",
+                  "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz",
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz"
                 }
               }
             }
@@ -2926,9 +3023,9 @@
               "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
             },
             "inherits": {
-              "version": "2.0.1",
-              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+              "version": "2.0.3",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
             }
           }
         }
@@ -2940,9 +3037,9 @@
       "resolved": "https://registry.npmjs.org/superagent-promise/-/superagent-promise-0.2.0.tgz"
     },
     "tar-fs": {
-      "version": "1.12.0",
-      "from": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.12.0.tgz",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.12.0.tgz",
+      "version": "1.13.2",
+      "from": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.13.2.tgz",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.13.2.tgz",
       "dependencies": {
         "pump": {
           "version": "1.0.1",
@@ -2952,17 +3049,31 @@
             "end-of-stream": {
               "version": "1.1.0",
               "from": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz",
-              "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz"
+              "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz",
+              "dependencies": {
+                "once": {
+                  "version": "1.3.3",
+                  "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.2",
+                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+                    }
+                  }
+                }
+              }
             },
             "once": {
-              "version": "1.3.3",
-              "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-              "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+              "version": "1.4.0",
+              "from": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+              "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
               "dependencies": {
                 "wrappy": {
-                  "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                  "version": "1.0.2",
+                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                 }
               }
             }
@@ -2991,9 +3102,9 @@
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                 },
                 "inherits": {
-                  "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                  "version": "2.0.3",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                 },
                 "isarray": {
                   "version": "1.0.0",
@@ -3001,9 +3112,9 @@
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                 },
                 "process-nextick-args": {
-                  "version": "1.0.6",
-                  "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
-                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
+                  "version": "1.0.7",
+                  "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
@@ -3030,28 +3141,33 @@
               "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
               "dependencies": {
                 "wrappy": {
-                  "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                  "version": "1.0.2",
+                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                 }
               }
             }
           }
         },
         "readable-stream": {
-          "version": "2.1.2",
-          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.2.tgz",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.2.tgz",
+          "version": "2.1.5",
+          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
           "dependencies": {
+            "buffer-shims": {
+              "version": "1.0.0",
+              "from": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
+            },
             "core-util-is": {
               "version": "1.0.2",
               "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
               "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
             },
             "inherits": {
-              "version": "2.0.1",
-              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+              "version": "2.0.3",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
             },
             "isarray": {
               "version": "1.0.0",
@@ -3059,9 +3175,9 @@
               "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
             },
             "process-nextick-args": {
-              "version": "1.0.6",
-              "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
-              "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
+              "version": "1.0.7",
+              "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+              "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
             },
             "string_decoder": {
               "version": "0.10.31",
@@ -3110,9 +3226,9 @@
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.38.tgz",
               "dependencies": {
                 "core-js": {
-                  "version": "1.2.6",
-                  "from": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz",
-                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
+                  "version": "1.2.7",
+                  "from": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz"
                 }
               }
             },
@@ -3122,19 +3238,19 @@
               "resolved": "https://registry.npmjs.org/buffertools/-/buffertools-2.1.4.tgz"
             },
             "fast-azure-storage": {
-              "version": "0.3.3",
-              "from": "https://registry.npmjs.org/fast-azure-storage/-/fast-azure-storage-0.3.3.tgz",
-              "resolved": "https://registry.npmjs.org/fast-azure-storage/-/fast-azure-storage-0.3.3.tgz",
+              "version": "0.3.5",
+              "from": "https://registry.npmjs.org/fast-azure-storage/-/fast-azure-storage-0.3.5.tgz",
+              "resolved": "https://registry.npmjs.org/fast-azure-storage/-/fast-azure-storage-0.3.5.tgz",
               "dependencies": {
                 "pixl-xml": {
-                  "version": "1.0.6",
-                  "from": "https://registry.npmjs.org/pixl-xml/-/pixl-xml-1.0.6.tgz",
-                  "resolved": "https://registry.npmjs.org/pixl-xml/-/pixl-xml-1.0.6.tgz"
+                  "version": "1.0.9",
+                  "from": "https://registry.npmjs.org/pixl-xml/-/pixl-xml-1.0.9.tgz",
+                  "resolved": "https://registry.npmjs.org/pixl-xml/-/pixl-xml-1.0.9.tgz"
                 },
                 "libxmljs": {
-                  "version": "0.15.0",
-                  "from": "https://registry.npmjs.org/libxmljs/-/libxmljs-0.15.0.tgz",
-                  "resolved": "https://registry.npmjs.org/libxmljs/-/libxmljs-0.15.0.tgz",
+                  "version": "0.18.0",
+                  "from": "https://registry.npmjs.org/libxmljs/-/libxmljs-0.18.0.tgz",
+                  "resolved": "https://registry.npmjs.org/libxmljs/-/libxmljs-0.18.0.tgz",
                   "dependencies": {
                     "bindings": {
                       "version": "1.2.1",
@@ -3142,9 +3258,9 @@
                       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz"
                     },
                     "nan": {
-                      "version": "2.0.7",
-                      "from": "https://registry.npmjs.org/nan/-/nan-2.0.7.tgz",
-                      "resolved": "https://registry.npmjs.org/nan/-/nan-2.0.7.tgz"
+                      "version": "2.3.2",
+                      "from": "https://registry.npmjs.org/nan/-/nan-2.3.2.tgz",
+                      "resolved": "https://registry.npmjs.org/nan/-/nan-2.3.2.tgz"
                     }
                   }
                 }
@@ -3229,9 +3345,9 @@
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "inherits": {
-                      "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                      "version": "2.0.3",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                     }
                   }
                 },
@@ -3242,15 +3358,20 @@
                 }
               }
             },
+            "aws-sdk-promise": {
+              "version": "0.0.2",
+              "from": "https://registry.npmjs.org/aws-sdk-promise/-/aws-sdk-promise-0.0.2.tgz",
+              "resolved": "https://registry.npmjs.org/aws-sdk-promise/-/aws-sdk-promise-0.0.2.tgz"
+            },
             "babel-runtime": {
               "version": "5.8.38",
               "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.38.tgz",
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.38.tgz",
               "dependencies": {
                 "core-js": {
-                  "version": "1.2.6",
-                  "from": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz",
-                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
+                  "version": "1.2.7",
+                  "from": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz"
                 }
               }
             },
@@ -3330,9 +3451,9 @@
               }
             },
             "amqplib": {
-              "version": "0.4.1",
-              "from": "https://registry.npmjs.org/amqplib/-/amqplib-0.4.1.tgz",
-              "resolved": "https://registry.npmjs.org/amqplib/-/amqplib-0.4.1.tgz",
+              "version": "0.4.2",
+              "from": "https://registry.npmjs.org/amqplib/-/amqplib-0.4.2.tgz",
+              "resolved": "https://registry.npmjs.org/amqplib/-/amqplib-0.4.2.tgz",
               "dependencies": {
                 "bitsyntax": {
                   "version": "0.0.4",
@@ -3365,9 +3486,9 @@
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "inherits": {
-                      "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                      "version": "2.0.3",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                     }
                   }
                 },
@@ -3423,9 +3544,9 @@
               "resolved": "https://registry.npmjs.org/url-join/-/url-join-0.0.1.tgz"
             },
             "sockjs-client": {
-              "version": "1.1.0",
-              "from": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.1.0.tgz",
-              "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.1.0.tgz",
+              "version": "1.1.1",
+              "from": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.1.1.tgz",
+              "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.1.1.tgz",
               "dependencies": {
                 "eventsource": {
                   "version": "0.1.6",
@@ -3443,9 +3564,9 @@
                           "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.0.5.tgz",
                           "dependencies": {
                             "querystringify": {
-                              "version": "0.0.3",
-                              "from": "https://registry.npmjs.org/querystringify/-/querystringify-0.0.3.tgz",
-                              "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-0.0.3.tgz"
+                              "version": "0.0.4",
+                              "from": "https://registry.npmjs.org/querystringify/-/querystringify-0.0.4.tgz",
+                              "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-0.0.4.tgz"
                             },
                             "requires-port": {
                               "version": "1.0.0",
@@ -3464,9 +3585,9 @@
                   "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.0.tgz",
                   "dependencies": {
                     "websocket-driver": {
-                      "version": "0.6.4",
-                      "from": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.6.4.tgz",
-                      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.6.4.tgz",
+                      "version": "0.6.5",
+                      "from": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.6.5.tgz",
+                      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.6.5.tgz",
                       "dependencies": {
                         "websocket-extensions": {
                           "version": "0.1.1",
@@ -3478,9 +3599,9 @@
                   }
                 },
                 "inherits": {
-                  "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                  "version": "2.0.3",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                 },
                 "json3": {
                   "version": "3.3.2",
@@ -3488,14 +3609,14 @@
                   "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz"
                 },
                 "url-parse": {
-                  "version": "1.1.1",
-                  "from": "https://registry.npmjs.org/url-parse/-/url-parse-1.1.1.tgz",
-                  "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.1.1.tgz",
+                  "version": "1.1.3",
+                  "from": "https://registry.npmjs.org/url-parse/-/url-parse-1.1.3.tgz",
+                  "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.1.3.tgz",
                   "dependencies": {
                     "querystringify": {
-                      "version": "0.0.3",
-                      "from": "https://registry.npmjs.org/querystringify/-/querystringify-0.0.3.tgz",
-                      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-0.0.3.tgz"
+                      "version": "0.0.4",
+                      "from": "https://registry.npmjs.org/querystringify/-/querystringify-0.0.4.tgz",
+                      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-0.0.4.tgz"
                     },
                     "requires-port": {
                       "version": "1.0.0",
@@ -3537,15 +3658,39 @@
                 }
               }
             },
+            "aws-sdk-promise": {
+              "version": "0.0.2",
+              "from": "https://registry.npmjs.org/aws-sdk-promise/-/aws-sdk-promise-0.0.2.tgz",
+              "resolved": "https://registry.npmjs.org/aws-sdk-promise/-/aws-sdk-promise-0.0.2.tgz",
+              "dependencies": {
+                "promise": {
+                  "version": "6.1.0",
+                  "from": "https://registry.npmjs.org/promise/-/promise-6.1.0.tgz",
+                  "resolved": "https://registry.npmjs.org/promise/-/promise-6.1.0.tgz",
+                  "dependencies": {
+                    "asap": {
+                      "version": "1.0.0",
+                      "from": "https://registry.npmjs.org/asap/-/asap-1.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/asap/-/asap-1.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
             "babel-runtime": {
-              "version": "6.6.1",
-              "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.6.1.tgz",
-              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.6.1.tgz",
+              "version": "6.11.6",
+              "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.11.6.tgz",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.11.6.tgz",
               "dependencies": {
                 "core-js": {
-                  "version": "2.3.0",
-                  "from": "https://registry.npmjs.org/core-js/-/core-js-2.3.0.tgz",
-                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.3.0.tgz"
+                  "version": "2.4.1",
+                  "from": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
+                },
+                "regenerator-runtime": {
+                  "version": "0.9.5",
+                  "from": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.9.5.tgz",
+                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.9.5.tgz"
                 }
               }
             },
@@ -3560,9 +3705,9 @@
                   "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.1.0.tgz"
                 },
                 "content-type": {
-                  "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/content-type/-/content-type-1.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.1.tgz"
+                  "version": "1.0.2",
+                  "from": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz",
+                  "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz"
                 },
                 "depd": {
                   "version": "1.0.1",
@@ -3575,14 +3720,14 @@
                   "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
                   "dependencies": {
                     "inherits": {
-                      "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                      "version": "2.0.3",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                     },
                     "statuses": {
-                      "version": "1.2.1",
-                      "from": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz",
-                      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz"
+                      "version": "1.3.0",
+                      "from": "https://registry.npmjs.org/statuses/-/statuses-1.3.0.tgz",
+                      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.0.tgz"
                     }
                   }
                 },
@@ -3609,14 +3754,14 @@
                   "resolved": "https://registry.npmjs.org/qs/-/qs-4.0.0.tgz"
                 },
                 "raw-body": {
-                  "version": "2.1.6",
-                  "from": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.6.tgz",
-                  "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.6.tgz",
+                  "version": "2.1.7",
+                  "from": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.7.tgz",
+                  "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.7.tgz",
                   "dependencies": {
                     "bytes": {
-                      "version": "2.3.0",
-                      "from": "https://registry.npmjs.org/bytes/-/bytes-2.3.0.tgz",
-                      "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.3.0.tgz"
+                      "version": "2.4.0",
+                      "from": "https://registry.npmjs.org/bytes/-/bytes-2.4.0.tgz",
+                      "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.4.0.tgz"
                     },
                     "iconv-lite": {
                       "version": "0.4.13",
@@ -4069,9 +4214,9 @@
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "inherits": {
-                      "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                      "version": "2.0.3",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                     }
                   }
                 }
@@ -4117,9 +4262,9 @@
               "resolved": "https://registry.npmjs.org/superagent-promise/-/superagent-promise-0.1.2.tgz"
             },
             "type-is": {
-              "version": "1.6.12",
-              "from": "https://registry.npmjs.org/type-is/-/type-is-1.6.12.tgz",
-              "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.12.tgz",
+              "version": "1.6.13",
+              "from": "https://registry.npmjs.org/type-is/-/type-is-1.6.13.tgz",
+              "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.13.tgz",
               "dependencies": {
                 "media-typer": {
                   "version": "0.3.0",
@@ -4127,23 +4272,23 @@
                   "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
                 },
                 "mime-types": {
-                  "version": "2.1.11",
-                  "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz",
-                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz",
+                  "version": "2.1.12",
+                  "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
+                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
                   "dependencies": {
                     "mime-db": {
-                      "version": "1.23.0",
-                      "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz",
-                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz"
+                      "version": "1.24.0",
+                      "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz",
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz"
                     }
                   }
                 }
               }
             },
             "uuid": {
-              "version": "2.0.2",
-              "from": "https://registry.npmjs.org/uuid/-/uuid-2.0.2.tgz",
-              "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.2.tgz"
+              "version": "2.0.3",
+              "from": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
+              "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz"
             }
           }
         },
@@ -4153,14 +4298,19 @@
           "resolved": "https://registry.npmjs.org/taskcluster-lib-app/-/taskcluster-lib-app-0.8.10.tgz",
           "dependencies": {
             "babel-runtime": {
-              "version": "6.6.1",
-              "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.6.1.tgz",
-              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.6.1.tgz",
+              "version": "6.11.6",
+              "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.11.6.tgz",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.11.6.tgz",
               "dependencies": {
                 "core-js": {
-                  "version": "2.3.0",
-                  "from": "https://registry.npmjs.org/core-js/-/core-js-2.3.0.tgz",
-                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.3.0.tgz"
+                  "version": "2.4.1",
+                  "from": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
+                },
+                "regenerator-runtime": {
+                  "version": "0.9.5",
+                  "from": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.9.5.tgz",
+                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.9.5.tgz"
                 }
               }
             },
@@ -4475,9 +4625,9 @@
                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                         },
                         "inherits": {
-                          "version": "2.0.1",
-                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                          "version": "2.0.3",
+                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                         }
                       }
                     },
@@ -4494,9 +4644,9 @@
                   "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.7.0.tgz",
                   "dependencies": {
                     "basic-auth": {
-                      "version": "1.0.3",
-                      "from": "https://registry.npmjs.org/basic-auth/-/basic-auth-1.0.3.tgz",
-                      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-1.0.3.tgz"
+                      "version": "1.0.4",
+                      "from": "https://registry.npmjs.org/basic-auth/-/basic-auth-1.0.4.tgz",
+                      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-1.0.4.tgz"
                     },
                     "depd": {
                       "version": "1.1.0",
@@ -4626,9 +4776,9 @@
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "inherits": {
-                      "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                      "version": "2.0.3",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                     }
                   }
                 }
@@ -4718,9 +4868,9 @@
                       "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
                     },
                     "tough-cookie": {
-                      "version": "2.2.2",
-                      "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.2.tgz",
-                      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.2.tgz"
+                      "version": "2.3.1",
+                      "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.1.tgz",
+                      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.1.tgz"
                     },
                     "form-data": {
                       "version": "0.1.4",
@@ -4864,9 +5014,9 @@
                   "resolved": "https://registry.npmjs.org/pathval/-/pathval-0.1.1.tgz"
                 },
                 "pruddy-error": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/pruddy-error/-/pruddy-error-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/pruddy-error/-/pruddy-error-1.0.0.tgz"
+                  "version": "1.0.2",
+                  "from": "https://registry.npmjs.org/pruddy-error/-/pruddy-error-1.0.2.tgz",
+                  "resolved": "https://registry.npmjs.org/pruddy-error/-/pruddy-error-1.0.2.tgz"
                 }
               }
             },
@@ -4876,9 +5026,9 @@
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.38.tgz",
               "dependencies": {
                 "core-js": {
-                  "version": "1.2.6",
-                  "from": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz",
-                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
+                  "version": "1.2.7",
+                  "from": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz"
                 }
               }
             },
@@ -4890,14 +5040,14 @@
           }
         },
         "taskcluster-lib-monitor": {
-          "version": "0.4.0",
-          "from": "https://registry.npmjs.org/taskcluster-lib-monitor/-/taskcluster-lib-monitor-0.4.0.tgz",
-          "resolved": "https://registry.npmjs.org/taskcluster-lib-monitor/-/taskcluster-lib-monitor-0.4.0.tgz",
+          "version": "0.4.1",
+          "from": "https://registry.npmjs.org/taskcluster-lib-monitor/-/taskcluster-lib-monitor-0.4.1.tgz",
+          "resolved": "https://registry.npmjs.org/taskcluster-lib-monitor/-/taskcluster-lib-monitor-0.4.1.tgz",
           "dependencies": {
             "assert": {
-              "version": "1.3.0",
-              "from": "https://registry.npmjs.org/assert/-/assert-1.3.0.tgz",
-              "resolved": "https://registry.npmjs.org/assert/-/assert-1.3.0.tgz",
+              "version": "1.4.1",
+              "from": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz",
+              "resolved": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz",
               "dependencies": {
                 "util": {
                   "version": "0.10.3",
@@ -4914,21 +5064,26 @@
               }
             },
             "babel-runtime": {
-              "version": "6.6.1",
-              "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.6.1.tgz",
-              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.6.1.tgz",
+              "version": "6.11.6",
+              "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.11.6.tgz",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.11.6.tgz",
               "dependencies": {
                 "core-js": {
-                  "version": "2.3.0",
-                  "from": "https://registry.npmjs.org/core-js/-/core-js-2.3.0.tgz",
-                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.3.0.tgz"
+                  "version": "2.4.1",
+                  "from": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
+                },
+                "regenerator-runtime": {
+                  "version": "0.9.5",
+                  "from": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.9.5.tgz",
+                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.9.5.tgz"
                 }
               }
             },
             "lodash": {
-              "version": "4.11.2",
-              "from": "https://registry.npmjs.org/lodash/-/lodash-4.11.2.tgz",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.11.2.tgz"
+              "version": "4.16.3",
+              "from": "https://registry.npmjs.org/lodash/-/lodash-4.16.3.tgz",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.3.tgz"
             },
             "raven": {
               "version": "0.10.0",
@@ -4958,14 +5113,14 @@
               }
             },
             "statsum": {
-              "version": "0.4.2",
-              "from": "https://registry.npmjs.org/statsum/-/statsum-0.4.2.tgz",
-              "resolved": "https://registry.npmjs.org/statsum/-/statsum-0.4.2.tgz",
+              "version": "0.4.3",
+              "from": "https://registry.npmjs.org/statsum/-/statsum-0.4.3.tgz",
+              "resolved": "https://registry.npmjs.org/statsum/-/statsum-0.4.3.tgz",
               "dependencies": {
                 "get-stream": {
-                  "version": "2.2.0",
-                  "from": "https://registry.npmjs.org/get-stream/-/get-stream-2.2.0.tgz",
-                  "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-2.2.0.tgz",
+                  "version": "2.3.1",
+                  "from": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
+                  "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
                   "dependencies": {
                     "object-assign": {
                       "version": "4.1.0",
@@ -5007,9 +5162,9 @@
                               "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz",
                               "dependencies": {
                                 "inherits": {
-                                  "version": "2.0.1",
-                                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                  "version": "2.0.3",
+                                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                                 },
                                 "typedarray": {
                                   "version": "0.0.6",
@@ -5078,14 +5233,14 @@
                                       "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
                                       "dependencies": {
                                         "is-finite": {
-                                          "version": "1.0.1",
-                                          "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
-                                          "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                                          "version": "1.0.2",
+                                          "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+                                          "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
                                           "dependencies": {
                                             "number-is-nan": {
-                                              "version": "1.0.0",
-                                              "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
-                                              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                                              "version": "1.0.1",
+                                              "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+                                              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
                                             }
                                           }
                                         }
@@ -5118,14 +5273,14 @@
                               "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz"
                             },
                             "ecdsa-sig-formatter": {
-                              "version": "1.0.5",
-                              "from": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.5.tgz",
-                              "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.5.tgz",
+                              "version": "1.0.7",
+                              "from": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.7.tgz",
+                              "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.7.tgz",
                               "dependencies": {
                                 "base64-url": {
-                                  "version": "1.2.2",
-                                  "from": "https://registry.npmjs.org/base64-url/-/base64-url-1.2.2.tgz",
-                                  "resolved": "https://registry.npmjs.org/base64-url/-/base64-url-1.2.2.tgz"
+                                  "version": "1.3.2",
+                                  "from": "https://registry.npmjs.org/base64-url/-/base64-url-1.3.2.tgz",
+                                  "resolved": "https://registry.npmjs.org/base64-url/-/base64-url-1.3.2.tgz"
                                 }
                               }
                             }
@@ -5259,9 +5414,9 @@
                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                         },
                         "inherits": {
-                          "version": "2.0.1",
-                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                          "version": "2.0.3",
+                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                         }
                       }
                     }
@@ -5307,9 +5462,9 @@
                   }
                 },
                 "amqplib": {
-                  "version": "0.4.1",
-                  "from": "https://registry.npmjs.org/amqplib/-/amqplib-0.4.1.tgz",
-                  "resolved": "https://registry.npmjs.org/amqplib/-/amqplib-0.4.1.tgz",
+                  "version": "0.4.2",
+                  "from": "https://registry.npmjs.org/amqplib/-/amqplib-0.4.2.tgz",
+                  "resolved": "https://registry.npmjs.org/amqplib/-/amqplib-0.4.2.tgz",
                   "dependencies": {
                     "bitsyntax": {
                       "version": "0.0.4",
@@ -5342,9 +5497,9 @@
                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                         },
                         "inherits": {
-                          "version": "2.0.1",
-                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                          "version": "2.0.3",
+                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                         }
                       }
                     },
@@ -5400,9 +5555,9 @@
                   "resolved": "https://registry.npmjs.org/url-join/-/url-join-0.0.1.tgz"
                 },
                 "sockjs-client": {
-                  "version": "1.1.0",
-                  "from": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.1.0.tgz",
-                  "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.1.0.tgz",
+                  "version": "1.1.1",
+                  "from": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.1.1.tgz",
                   "dependencies": {
                     "eventsource": {
                       "version": "0.1.6",
@@ -5420,9 +5575,9 @@
                               "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.0.5.tgz",
                               "dependencies": {
                                 "querystringify": {
-                                  "version": "0.0.3",
-                                  "from": "https://registry.npmjs.org/querystringify/-/querystringify-0.0.3.tgz",
-                                  "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-0.0.3.tgz"
+                                  "version": "0.0.4",
+                                  "from": "https://registry.npmjs.org/querystringify/-/querystringify-0.0.4.tgz",
+                                  "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-0.0.4.tgz"
                                 },
                                 "requires-port": {
                                   "version": "1.0.0",
@@ -5441,9 +5596,9 @@
                       "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.0.tgz",
                       "dependencies": {
                         "websocket-driver": {
-                          "version": "0.6.4",
-                          "from": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.6.4.tgz",
-                          "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.6.4.tgz",
+                          "version": "0.6.5",
+                          "from": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.6.5.tgz",
+                          "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.6.5.tgz",
                           "dependencies": {
                             "websocket-extensions": {
                               "version": "0.1.1",
@@ -5455,9 +5610,9 @@
                       }
                     },
                     "inherits": {
-                      "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                      "version": "2.0.3",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                     },
                     "json3": {
                       "version": "3.3.2",
@@ -5465,14 +5620,14 @@
                       "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz"
                     },
                     "url-parse": {
-                      "version": "1.1.1",
-                      "from": "https://registry.npmjs.org/url-parse/-/url-parse-1.1.1.tgz",
-                      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.1.1.tgz",
+                      "version": "1.1.3",
+                      "from": "https://registry.npmjs.org/url-parse/-/url-parse-1.1.3.tgz",
+                      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.1.3.tgz",
                       "dependencies": {
                         "querystringify": {
-                          "version": "0.0.3",
-                          "from": "https://registry.npmjs.org/querystringify/-/querystringify-0.0.3.tgz",
-                          "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-0.0.3.tgz"
+                          "version": "0.0.4",
+                          "from": "https://registry.npmjs.org/querystringify/-/querystringify-0.0.4.tgz",
+                          "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-0.0.4.tgz"
                         },
                         "requires-port": {
                           "version": "1.0.0",
@@ -5496,9 +5651,9 @@
                   "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz"
                 },
                 "nan": {
-                  "version": "2.3.2",
-                  "from": "https://registry.npmjs.org/nan/-/nan-2.3.2.tgz",
-                  "resolved": "https://registry.npmjs.org/nan/-/nan-2.3.2.tgz"
+                  "version": "2.4.0",
+                  "from": "https://registry.npmjs.org/nan/-/nan-2.4.0.tgz",
+                  "resolved": "https://registry.npmjs.org/nan/-/nan-2.4.0.tgz"
                 }
               }
             }
@@ -5515,9 +5670,9 @@
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.38.tgz",
               "dependencies": {
                 "core-js": {
-                  "version": "1.2.6",
-                  "from": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz",
-                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
+                  "version": "1.2.7",
+                  "from": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz"
                 }
               }
             }
@@ -5534,9 +5689,9 @@
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.38.tgz",
               "dependencies": {
                 "core-js": {
-                  "version": "1.2.6",
-                  "from": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz",
-                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
+                  "version": "1.2.7",
+                  "from": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz"
                 }
               }
             },
@@ -5637,9 +5792,9 @@
                   "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz"
                 },
                 "nan": {
-                  "version": "2.3.2",
-                  "from": "https://registry.npmjs.org/nan/-/nan-2.3.2.tgz",
-                  "resolved": "https://registry.npmjs.org/nan/-/nan-2.3.2.tgz"
+                  "version": "2.4.0",
+                  "from": "https://registry.npmjs.org/nan/-/nan-2.4.0.tgz",
+                  "resolved": "https://registry.npmjs.org/nan/-/nan-2.4.0.tgz"
                 }
               }
             }
@@ -5681,9 +5836,9 @@
                       "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
                     },
                     "tough-cookie": {
-                      "version": "2.2.2",
-                      "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.2.tgz",
-                      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.2.tgz"
+                      "version": "2.3.1",
+                      "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.1.tgz",
+                      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.1.tgz"
                     },
                     "form-data": {
                       "version": "0.1.4",
@@ -5788,14 +5943,19 @@
               }
             },
             "babel-runtime": {
-              "version": "6.6.1",
-              "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.6.1.tgz",
-              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.6.1.tgz",
+              "version": "6.11.6",
+              "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.11.6.tgz",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.11.6.tgz",
               "dependencies": {
                 "core-js": {
-                  "version": "2.3.0",
-                  "from": "https://registry.npmjs.org/core-js/-/core-js-2.3.0.tgz",
-                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.3.0.tgz"
+                  "version": "2.4.1",
+                  "from": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
+                },
+                "regenerator-runtime": {
+                  "version": "0.9.5",
+                  "from": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.9.5.tgz",
+                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.9.5.tgz"
                 }
               }
             },
@@ -6208,9 +6368,9 @@
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "inherits": {
-                      "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                      "version": "2.0.3",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                     }
                   }
                 }
@@ -6290,14 +6450,14 @@
                   "resolved": "https://registry.npmjs.org/app-root-dir/-/app-root-dir-1.0.2.tgz"
                 },
                 "js-yaml": {
-                  "version": "3.6.0",
-                  "from": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.0.tgz",
-                  "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.0.tgz",
+                  "version": "3.6.1",
+                  "from": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz",
+                  "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz",
                   "dependencies": {
                     "argparse": {
-                      "version": "1.0.7",
-                      "from": "https://registry.npmjs.org/argparse/-/argparse-1.0.7.tgz",
-                      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.7.tgz",
+                      "version": "1.0.9",
+                      "from": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
+                      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
                       "dependencies": {
                         "sprintf-js": {
                           "version": "1.0.3",
@@ -6307,16 +6467,16 @@
                       }
                     },
                     "esprima": {
-                      "version": "2.7.2",
-                      "from": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz",
-                      "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz"
+                      "version": "2.7.3",
+                      "from": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+                      "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz"
                     }
                   }
                 },
                 "lodash": {
-                  "version": "4.11.2",
-                  "from": "https://registry.npmjs.org/lodash/-/lodash-4.11.2.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.11.2.tgz"
+                  "version": "4.16.3",
+                  "from": "https://registry.npmjs.org/lodash/-/lodash-4.16.3.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.3.tgz"
                 },
                 "url-join": {
                   "version": "0.0.1",
@@ -6338,9 +6498,9 @@
               }
             },
             "uuid": {
-              "version": "2.0.2",
-              "from": "https://registry.npmjs.org/uuid/-/uuid-2.0.2.tgz",
-              "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.2.tgz"
+              "version": "2.0.3",
+              "from": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
+              "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz"
             },
             "nock": {
               "version": "4.1.0",
@@ -6353,9 +6513,9 @@
                   "resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
                   "dependencies": {
                     "assertion-error": {
-                      "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.1.tgz"
+                      "version": "1.0.2",
+                      "from": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
+                      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz"
                     },
                     "deep-eql": {
                       "version": "0.1.3",
@@ -6401,9 +6561,9 @@
           "resolved": "https://registry.npmjs.org/taskcluster-lib-validate/-/taskcluster-lib-validate-0.4.4.tgz",
           "dependencies": {
             "ajv": {
-              "version": "4.0.4",
-              "from": "https://registry.npmjs.org/ajv/-/ajv-4.0.4.tgz",
-              "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.0.4.tgz",
+              "version": "4.7.6",
+              "from": "https://registry.npmjs.org/ajv/-/ajv-4.7.6.tgz",
+              "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.7.6.tgz",
               "dependencies": {
                 "co": {
                   "version": "4.6.0",
@@ -6430,26 +6590,31 @@
               "resolved": "https://registry.npmjs.org/app-root-dir/-/app-root-dir-1.0.2.tgz"
             },
             "babel-runtime": {
-              "version": "6.6.1",
-              "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.6.1.tgz",
-              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.6.1.tgz",
+              "version": "6.11.6",
+              "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.11.6.tgz",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.11.6.tgz",
               "dependencies": {
                 "core-js": {
-                  "version": "2.3.0",
-                  "from": "https://registry.npmjs.org/core-js/-/core-js-2.3.0.tgz",
-                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.3.0.tgz"
+                  "version": "2.4.1",
+                  "from": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
+                },
+                "regenerator-runtime": {
+                  "version": "0.9.5",
+                  "from": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.9.5.tgz",
+                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.9.5.tgz"
                 }
               }
             },
             "js-yaml": {
-              "version": "3.6.0",
-              "from": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.0.tgz",
-              "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.0.tgz",
+              "version": "3.6.1",
+              "from": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz",
+              "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz",
               "dependencies": {
                 "argparse": {
-                  "version": "1.0.7",
-                  "from": "https://registry.npmjs.org/argparse/-/argparse-1.0.7.tgz",
-                  "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.7.tgz",
+                  "version": "1.0.9",
+                  "from": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
+                  "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
                   "dependencies": {
                     "sprintf-js": {
                       "version": "1.0.3",
@@ -6459,16 +6624,16 @@
                   }
                 },
                 "esprima": {
-                  "version": "2.7.2",
-                  "from": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz",
-                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz"
+                  "version": "2.7.3",
+                  "from": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz"
                 }
               }
             },
             "lodash": {
-              "version": "4.11.2",
-              "from": "https://registry.npmjs.org/lodash/-/lodash-4.11.2.tgz",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.11.2.tgz"
+              "version": "4.16.3",
+              "from": "https://registry.npmjs.org/lodash/-/lodash-4.16.3.tgz",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.3.tgz"
             },
             "url-join": {
               "version": "1.1.0",
@@ -6500,21 +6665,21 @@
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.38.tgz",
               "dependencies": {
                 "core-js": {
-                  "version": "1.2.6",
-                  "from": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz",
-                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
+                  "version": "1.2.7",
+                  "from": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz"
                 }
               }
             },
             "js-yaml": {
-              "version": "3.6.0",
-              "from": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.0.tgz",
-              "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.0.tgz",
+              "version": "3.6.1",
+              "from": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz",
+              "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz",
               "dependencies": {
                 "argparse": {
-                  "version": "1.0.7",
-                  "from": "https://registry.npmjs.org/argparse/-/argparse-1.0.7.tgz",
-                  "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.7.tgz",
+                  "version": "1.0.9",
+                  "from": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
+                  "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
                   "dependencies": {
                     "sprintf-js": {
                       "version": "1.0.3",
@@ -6524,9 +6689,9 @@
                   }
                 },
                 "esprima": {
-                  "version": "2.7.2",
-                  "from": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz",
-                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz"
+                  "version": "2.7.3",
+                  "from": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz"
                 }
               }
             }
@@ -6535,10 +6700,115 @@
       }
     },
     "taskcluster-client": {
-      "version": "0.22.6",
-      "from": "https://registry.npmjs.org/taskcluster-client/-/taskcluster-client-0.22.6.tgz",
-      "resolved": "https://registry.npmjs.org/taskcluster-client/-/taskcluster-client-0.22.6.tgz",
+      "version": "1.4.0",
+      "from": "https://registry.npmjs.org/taskcluster-client/-/taskcluster-client-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/taskcluster-client/-/taskcluster-client-1.4.0.tgz",
       "dependencies": {
+        "superagent": {
+          "version": "1.7.2",
+          "from": "https://registry.npmjs.org/superagent/-/superagent-1.7.2.tgz",
+          "resolved": "https://registry.npmjs.org/superagent/-/superagent-1.7.2.tgz",
+          "dependencies": {
+            "qs": {
+              "version": "2.3.3",
+              "from": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
+            },
+            "formidable": {
+              "version": "1.0.17",
+              "from": "https://registry.npmjs.org/formidable/-/formidable-1.0.17.tgz",
+              "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.0.17.tgz"
+            },
+            "component-emitter": {
+              "version": "1.2.1",
+              "from": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+              "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz"
+            },
+            "methods": {
+              "version": "1.1.2",
+              "from": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+              "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz"
+            },
+            "cookiejar": {
+              "version": "2.0.6",
+              "from": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.0.6.tgz",
+              "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.0.6.tgz"
+            },
+            "reduce-component": {
+              "version": "1.0.1",
+              "from": "https://registry.npmjs.org/reduce-component/-/reduce-component-1.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/reduce-component/-/reduce-component-1.0.1.tgz"
+            },
+            "extend": {
+              "version": "3.0.0",
+              "from": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
+            },
+            "form-data": {
+              "version": "0.2.0",
+              "from": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
+              "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
+              "dependencies": {
+                "async": {
+                  "version": "0.9.2",
+                  "from": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+                  "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
+                },
+                "combined-stream": {
+                  "version": "0.0.7",
+                  "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+                  "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+                  "dependencies": {
+                    "delayed-stream": {
+                      "version": "0.0.5",
+                      "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
+                      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                    }
+                  }
+                },
+                "mime-types": {
+                  "version": "2.0.14",
+                  "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
+                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
+                  "dependencies": {
+                    "mime-db": {
+                      "version": "1.12.0",
+                      "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz",
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "readable-stream": {
+              "version": "1.0.27-1",
+              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.27-1.tgz",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.27-1.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.2",
+                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.3",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+                }
+              }
+            }
+          }
+        },
         "superagent-hawk": {
           "version": "0.0.6",
           "from": "https://registry.npmjs.org/superagent-hawk/-/superagent-hawk-0.0.6.tgz",
@@ -6579,9 +6849,9 @@
           }
         },
         "amqplib": {
-          "version": "0.3.2",
-          "from": "https://registry.npmjs.org/amqplib/-/amqplib-0.3.2.tgz",
-          "resolved": "https://registry.npmjs.org/amqplib/-/amqplib-0.3.2.tgz",
+          "version": "0.4.2",
+          "from": "https://registry.npmjs.org/amqplib/-/amqplib-0.4.2.tgz",
+          "resolved": "https://registry.npmjs.org/amqplib/-/amqplib-0.4.2.tgz",
           "dependencies": {
             "bitsyntax": {
               "version": "0.0.4",
@@ -6614,9 +6884,9 @@
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "inherits": {
-                  "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                  "version": "2.0.3",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                 }
               }
             },
@@ -6671,229 +6941,35 @@
           "from": "https://registry.npmjs.org/url-join/-/url-join-0.0.1.tgz",
           "resolved": "https://registry.npmjs.org/url-join/-/url-join-0.0.1.tgz"
         },
-        "sockjs-client-node": {
-          "version": "0.2.1",
-          "from": "https://registry.npmjs.org/sockjs-client-node/-/sockjs-client-node-0.2.1.tgz",
-          "resolved": "https://registry.npmjs.org/sockjs-client-node/-/sockjs-client-node-0.2.1.tgz",
+        "sockjs-client": {
+          "version": "1.1.1",
+          "from": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.1.1.tgz",
           "dependencies": {
-            "jsdom": {
-              "version": "3.1.2",
-              "from": "https://registry.npmjs.org/jsdom/-/jsdom-3.1.2.tgz",
-              "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-3.1.2.tgz",
+            "eventsource": {
+              "version": "0.1.6",
+              "from": "https://registry.npmjs.org/eventsource/-/eventsource-0.1.6.tgz",
+              "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-0.1.6.tgz",
               "dependencies": {
-                "browser-request": {
-                  "version": "0.3.3",
-                  "from": "https://registry.npmjs.org/browser-request/-/browser-request-0.3.3.tgz",
-                  "resolved": "https://registry.npmjs.org/browser-request/-/browser-request-0.3.3.tgz"
-                },
-                "contextify": {
-                  "version": "0.1.15",
-                  "from": "https://registry.npmjs.org/contextify/-/contextify-0.1.15.tgz",
-                  "resolved": "https://registry.npmjs.org/contextify/-/contextify-0.1.15.tgz",
-                  "dependencies": {
-                    "bindings": {
-                      "version": "1.2.1",
-                      "from": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz",
-                      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz"
-                    },
-                    "nan": {
-                      "version": "2.3.2",
-                      "from": "https://registry.npmjs.org/nan/-/nan-2.3.2.tgz",
-                      "resolved": "https://registry.npmjs.org/nan/-/nan-2.3.2.tgz"
-                    }
-                  }
-                },
-                "cssom": {
-                  "version": "0.3.1",
-                  "from": "https://registry.npmjs.org/cssom/-/cssom-0.3.1.tgz",
-                  "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.1.tgz"
-                },
-                "cssstyle": {
-                  "version": "0.2.34",
-                  "from": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.34.tgz",
-                  "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.34.tgz"
-                },
-                "htmlparser2": {
-                  "version": "3.9.0",
-                  "from": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.0.tgz",
-                  "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.0.tgz",
-                  "dependencies": {
-                    "domelementtype": {
-                      "version": "1.3.0",
-                      "from": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
-                      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
-                    },
-                    "domhandler": {
-                      "version": "2.3.0",
-                      "from": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
-                      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz"
-                    },
-                    "domutils": {
-                      "version": "1.5.1",
-                      "from": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
-                      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
-                      "dependencies": {
-                        "dom-serializer": {
-                          "version": "0.1.0",
-                          "from": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
-                          "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
-                          "dependencies": {
-                            "domelementtype": {
-                              "version": "1.1.3",
-                              "from": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
-                              "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "entities": {
-                      "version": "1.1.1",
-                      "from": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
-                      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz"
-                    },
-                    "readable-stream": {
-                      "version": "2.1.2",
-                      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.2.tgz",
-                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.2.tgz",
-                      "dependencies": {
-                        "core-util-is": {
-                          "version": "1.0.2",
-                          "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                        },
-                        "inherits": {
-                          "version": "2.0.1",
-                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                        },
-                        "isarray": {
-                          "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-                        },
-                        "process-nextick-args": {
-                          "version": "1.0.6",
-                          "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
-                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
-                        },
-                        "string_decoder": {
-                          "version": "0.10.31",
-                          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                        },
-                        "util-deprecate": {
-                          "version": "1.0.2",
-                          "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-                          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "nwmatcher": {
-                  "version": "1.3.7",
-                  "from": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.3.7.tgz",
-                  "resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.3.7.tgz"
-                },
-                "parse5": {
-                  "version": "1.5.1",
-                  "from": "https://registry.npmjs.org/parse5/-/parse5-1.5.1.tgz",
-                  "resolved": "https://registry.npmjs.org/parse5/-/parse5-1.5.1.tgz"
-                },
-                "xml-name-validator": {
+                "original": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-1.0.0.tgz"
-                },
-                "xmlhttprequest": {
-                  "version": "1.8.0",
-                  "from": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
-                  "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz"
-                },
-                "acorn-globals": {
-                  "version": "1.0.9",
-                  "from": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-1.0.9.tgz",
-                  "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-1.0.9.tgz",
+                  "from": "https://registry.npmjs.org/original/-/original-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/original/-/original-1.0.0.tgz",
                   "dependencies": {
-                    "acorn": {
-                      "version": "2.7.0",
-                      "from": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz",
-                      "resolved": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz"
-                    }
-                  }
-                },
-                "acorn": {
-                  "version": "0.11.0",
-                  "from": "https://registry.npmjs.org/acorn/-/acorn-0.11.0.tgz",
-                  "resolved": "https://registry.npmjs.org/acorn/-/acorn-0.11.0.tgz"
-                },
-                "escodegen": {
-                  "version": "1.8.0",
-                  "from": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.0.tgz",
-                  "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.0.tgz",
-                  "dependencies": {
-                    "estraverse": {
-                      "version": "1.9.3",
-                      "from": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
-                      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz"
-                    },
-                    "esutils": {
-                      "version": "2.0.2",
-                      "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                    },
-                    "esprima": {
-                      "version": "2.7.2",
-                      "from": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz",
-                      "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz"
-                    },
-                    "optionator": {
-                      "version": "0.8.1",
-                      "from": "https://registry.npmjs.org/optionator/-/optionator-0.8.1.tgz",
-                      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.1.tgz",
+                    "url-parse": {
+                      "version": "1.0.5",
+                      "from": "https://registry.npmjs.org/url-parse/-/url-parse-1.0.5.tgz",
+                      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.0.5.tgz",
                       "dependencies": {
-                        "prelude-ls": {
-                          "version": "1.1.2",
-                          "from": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-                          "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
+                        "querystringify": {
+                          "version": "0.0.4",
+                          "from": "https://registry.npmjs.org/querystringify/-/querystringify-0.0.4.tgz",
+                          "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-0.0.4.tgz"
                         },
-                        "deep-is": {
-                          "version": "0.1.3",
-                          "from": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-                          "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
-                        },
-                        "wordwrap": {
+                        "requires-port": {
                           "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-                          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz"
-                        },
-                        "type-check": {
-                          "version": "0.3.2",
-                          "from": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-                          "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz"
-                        },
-                        "levn": {
-                          "version": "0.3.0",
-                          "from": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-                          "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz"
-                        },
-                        "fast-levenshtein": {
-                          "version": "1.1.3",
-                          "from": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.1.3.tgz",
-                          "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.1.3.tgz"
-                        }
-                      }
-                    },
-                    "source-map": {
-                      "version": "0.2.0",
-                      "from": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
-                      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
-                      "dependencies": {
-                        "amdefine": {
-                          "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
-                          "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+                          "from": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz"
                         }
                       }
                     }
@@ -6901,197 +6977,49 @@
                 }
               }
             },
-            "primus": {
-              "version": "2.4.12",
-              "from": "https://registry.npmjs.org/primus/-/primus-2.4.12.tgz",
-              "resolved": "https://registry.npmjs.org/primus/-/primus-2.4.12.tgz",
+            "faye-websocket": {
+              "version": "0.11.0",
+              "from": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.0.tgz",
+              "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.0.tgz",
               "dependencies": {
-                "access-control": {
-                  "version": "0.0.8",
-                  "from": "https://registry.npmjs.org/access-control/-/access-control-0.0.8.tgz",
-                  "resolved": "https://registry.npmjs.org/access-control/-/access-control-0.0.8.tgz",
+                "websocket-driver": {
+                  "version": "0.6.5",
+                  "from": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.6.5.tgz",
+                  "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.6.5.tgz",
                   "dependencies": {
-                    "millisecond": {
-                      "version": "0.1.2",
-                      "from": "https://registry.npmjs.org/millisecond/-/millisecond-0.1.2.tgz",
-                      "resolved": "https://registry.npmjs.org/millisecond/-/millisecond-0.1.2.tgz"
-                    },
-                    "vary": {
-                      "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/vary/-/vary-1.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/vary/-/vary-1.0.1.tgz"
+                    "websocket-extensions": {
+                      "version": "0.1.1",
+                      "from": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.1.tgz",
+                      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.1.tgz"
                     }
                   }
-                },
-                "create-server": {
-                  "version": "0.0.7",
-                  "from": "https://registry.npmjs.org/create-server/-/create-server-0.0.7.tgz",
-                  "resolved": "https://registry.npmjs.org/create-server/-/create-server-0.0.7.tgz",
-                  "dependencies": {
-                    "connected": {
-                      "version": "0.0.2",
-                      "from": "https://registry.npmjs.org/connected/-/connected-0.0.2.tgz",
-                      "resolved": "https://registry.npmjs.org/connected/-/connected-0.0.2.tgz"
-                    }
-                  }
-                },
-                "diagnostics": {
-                  "version": "0.0.4",
-                  "from": "https://registry.npmjs.org/diagnostics/-/diagnostics-0.0.4.tgz",
-                  "resolved": "https://registry.npmjs.org/diagnostics/-/diagnostics-0.0.4.tgz",
-                  "dependencies": {
-                    "color": {
-                      "version": "0.7.3",
-                      "from": "https://registry.npmjs.org/color/-/color-0.7.3.tgz",
-                      "resolved": "https://registry.npmjs.org/color/-/color-0.7.3.tgz",
-                      "dependencies": {
-                        "color-convert": {
-                          "version": "0.5.3",
-                          "from": "https://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz",
-                          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz"
-                        },
-                        "color-string": {
-                          "version": "0.2.4",
-                          "from": "https://registry.npmjs.org/color-string/-/color-string-0.2.4.tgz",
-                          "resolved": "https://registry.npmjs.org/color-string/-/color-string-0.2.4.tgz",
-                          "dependencies": {
-                            "color-name": {
-                              "version": "1.0.1",
-                              "from": "https://registry.npmjs.org/color-name/-/color-name-1.0.1.tgz",
-                              "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.0.1.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "colornames": {
-                      "version": "0.0.2",
-                      "from": "https://registry.npmjs.org/colornames/-/colornames-0.0.2.tgz",
-                      "resolved": "https://registry.npmjs.org/colornames/-/colornames-0.0.2.tgz"
-                    },
-                    "env-variable": {
-                      "version": "0.0.3",
-                      "from": "https://registry.npmjs.org/env-variable/-/env-variable-0.0.3.tgz",
-                      "resolved": "https://registry.npmjs.org/env-variable/-/env-variable-0.0.3.tgz"
-                    },
-                    "kuler": {
-                      "version": "0.0.0",
-                      "from": "https://registry.npmjs.org/kuler/-/kuler-0.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/kuler/-/kuler-0.0.0.tgz"
-                    },
-                    "text-hex": {
-                      "version": "0.0.0",
-                      "from": "https://registry.npmjs.org/text-hex/-/text-hex-0.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-0.0.0.tgz"
-                    }
-                  }
-                },
-                "eventemitter3": {
-                  "version": "0.1.6",
-                  "from": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-0.1.6.tgz",
-                  "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-0.1.6.tgz"
-                },
-                "forwarded-for": {
-                  "version": "0.1.1",
-                  "from": "https://registry.npmjs.org/forwarded-for/-/forwarded-for-0.1.1.tgz",
-                  "resolved": "https://registry.npmjs.org/forwarded-for/-/forwarded-for-0.1.1.tgz"
-                },
-                "fusing": {
-                  "version": "0.4.0",
-                  "from": "https://registry.npmjs.org/fusing/-/fusing-0.4.0.tgz",
-                  "resolved": "https://registry.npmjs.org/fusing/-/fusing-0.4.0.tgz",
-                  "dependencies": {
-                    "emits": {
-                      "version": "1.0.2",
-                      "from": "https://registry.npmjs.org/emits/-/emits-1.0.2.tgz",
-                      "resolved": "https://registry.npmjs.org/emits/-/emits-1.0.2.tgz"
-                    },
-                    "predefine": {
-                      "version": "0.1.2",
-                      "from": "https://registry.npmjs.org/predefine/-/predefine-0.1.2.tgz",
-                      "resolved": "https://registry.npmjs.org/predefine/-/predefine-0.1.2.tgz",
-                      "dependencies": {
-                        "extendible": {
-                          "version": "0.1.1",
-                          "from": "https://registry.npmjs.org/extendible/-/extendible-0.1.1.tgz",
-                          "resolved": "https://registry.npmjs.org/extendible/-/extendible-0.1.1.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "load": {
-                  "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/load/-/load-1.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/load/-/load-1.0.2.tgz"
-                },
-                "setheader": {
-                  "version": "0.0.4",
-                  "from": "https://registry.npmjs.org/setheader/-/setheader-0.0.4.tgz",
-                  "resolved": "https://registry.npmjs.org/setheader/-/setheader-0.0.4.tgz",
-                  "dependencies": {
-                    "debug": {
-                      "version": "0.7.4",
-                      "from": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
-                      "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
-                    }
-                  }
-                },
-                "ultron": {
-                  "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz"
                 }
               }
             },
-            "ws": {
-              "version": "0.7.2",
-              "from": "https://registry.npmjs.org/ws/-/ws-0.7.2.tgz",
-              "resolved": "https://registry.npmjs.org/ws/-/ws-0.7.2.tgz",
+            "inherits": {
+              "version": "2.0.3",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+            },
+            "json3": {
+              "version": "3.3.2",
+              "from": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
+              "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz"
+            },
+            "url-parse": {
+              "version": "1.1.3",
+              "from": "https://registry.npmjs.org/url-parse/-/url-parse-1.1.3.tgz",
+              "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.1.3.tgz",
               "dependencies": {
-                "options": {
-                  "version": "0.0.6",
-                  "from": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
-                  "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz"
+                "querystringify": {
+                  "version": "0.0.4",
+                  "from": "https://registry.npmjs.org/querystringify/-/querystringify-0.0.4.tgz",
+                  "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-0.0.4.tgz"
                 },
-                "ultron": {
-                  "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz"
-                },
-                "bufferutil": {
-                  "version": "1.1.0",
-                  "from": "https://registry.npmjs.org/bufferutil/-/bufferutil-1.1.0.tgz",
-                  "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-1.1.0.tgz",
-                  "dependencies": {
-                    "bindings": {
-                      "version": "1.2.1",
-                      "from": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz",
-                      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz"
-                    },
-                    "nan": {
-                      "version": "1.8.4",
-                      "from": "https://registry.npmjs.org/nan/-/nan-1.8.4.tgz",
-                      "resolved": "https://registry.npmjs.org/nan/-/nan-1.8.4.tgz"
-                    }
-                  }
-                },
-                "utf-8-validate": {
-                  "version": "1.1.0",
-                  "from": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-1.1.0.tgz",
-                  "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-1.1.0.tgz",
-                  "dependencies": {
-                    "bindings": {
-                      "version": "1.2.1",
-                      "from": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz",
-                      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz"
-                    },
-                    "nan": {
-                      "version": "1.8.4",
-                      "from": "https://registry.npmjs.org/nan/-/nan-1.8.4.tgz",
-                      "resolved": "https://registry.npmjs.org/nan/-/nan-1.8.4.tgz"
-                    }
-                  }
+                "requires-port": {
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz"
                 }
               }
             }
@@ -7100,9 +7028,9 @@
       }
     },
     "taskcluster-lib-monitor": {
-      "version": "4.2.0",
-      "from": "https://registry.npmjs.org/taskcluster-lib-monitor/-/taskcluster-lib-monitor-4.2.0.tgz",
-      "resolved": "https://registry.npmjs.org/taskcluster-lib-monitor/-/taskcluster-lib-monitor-4.2.0.tgz",
+      "version": "4.3.1",
+      "from": "https://registry.npmjs.org/taskcluster-lib-monitor/-/taskcluster-lib-monitor-4.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/taskcluster-lib-monitor/-/taskcluster-lib-monitor-4.3.1.tgz",
       "dependencies": {
         "assert": {
           "version": "1.4.1",
@@ -7141,9 +7069,9 @@
           }
         },
         "lodash": {
-          "version": "4.15.0",
-          "from": "https://registry.npmjs.org/lodash/-/lodash-4.15.0.tgz",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.15.0.tgz"
+          "version": "4.16.3",
+          "from": "https://registry.npmjs.org/lodash/-/lodash-4.16.3.tgz",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.3.tgz"
         },
         "raven": {
           "version": "0.11.0",
@@ -7178,9 +7106,9 @@
           "resolved": "https://registry.npmjs.org/statsum/-/statsum-0.5.1.tgz",
           "dependencies": {
             "get-stream": {
-              "version": "2.3.0",
-              "from": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.0.tgz",
-              "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.0.tgz",
+              "version": "2.3.1",
+              "from": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
+              "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
               "dependencies": {
                 "object-assign": {
                   "version": "4.1.0",
@@ -7222,9 +7150,9 @@
                           "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz",
                           "dependencies": {
                             "inherits": {
-                              "version": "2.0.1",
-                              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                              "version": "2.0.3",
+                              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                             },
                             "typedarray": {
                               "version": "0.0.6",
@@ -7293,14 +7221,14 @@
                                   "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
                                   "dependencies": {
                                     "is-finite": {
-                                      "version": "1.0.1",
-                                      "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
-                                      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                                      "version": "1.0.2",
+                                      "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+                                      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
                                       "dependencies": {
                                         "number-is-nan": {
-                                          "version": "1.0.0",
-                                          "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
-                                          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                                          "version": "1.0.1",
+                                          "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+                                          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
                                         }
                                       }
                                     }
@@ -7366,342 +7294,9 @@
               "resolved": "https://registry.npmjs.org/url-join/-/url-join-0.0.1.tgz"
             },
             "uuid": {
-              "version": "2.0.2",
-              "from": "https://registry.npmjs.org/uuid/-/uuid-2.0.2.tgz",
-              "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.2.tgz"
-            }
-          }
-        },
-        "taskcluster-client": {
-          "version": "1.3.0",
-          "from": "https://registry.npmjs.org/taskcluster-client/-/taskcluster-client-1.3.0.tgz",
-          "resolved": "https://registry.npmjs.org/taskcluster-client/-/taskcluster-client-1.3.0.tgz",
-          "dependencies": {
-            "lodash": {
-              "version": "3.10.1",
-              "from": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
-            },
-            "superagent": {
-              "version": "1.7.2",
-              "from": "https://registry.npmjs.org/superagent/-/superagent-1.7.2.tgz",
-              "resolved": "https://registry.npmjs.org/superagent/-/superagent-1.7.2.tgz",
-              "dependencies": {
-                "qs": {
-                  "version": "2.3.3",
-                  "from": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz",
-                  "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
-                },
-                "formidable": {
-                  "version": "1.0.17",
-                  "from": "https://registry.npmjs.org/formidable/-/formidable-1.0.17.tgz",
-                  "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.0.17.tgz"
-                },
-                "component-emitter": {
-                  "version": "1.2.1",
-                  "from": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-                  "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz"
-                },
-                "methods": {
-                  "version": "1.1.2",
-                  "from": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-                  "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz"
-                },
-                "cookiejar": {
-                  "version": "2.0.6",
-                  "from": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.0.6.tgz",
-                  "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.0.6.tgz"
-                },
-                "reduce-component": {
-                  "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/reduce-component/-/reduce-component-1.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/reduce-component/-/reduce-component-1.0.1.tgz"
-                },
-                "extend": {
-                  "version": "3.0.0",
-                  "from": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
-                },
-                "form-data": {
-                  "version": "0.2.0",
-                  "from": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
-                  "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
-                  "dependencies": {
-                    "async": {
-                      "version": "0.9.2",
-                      "from": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
-                      "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
-                    },
-                    "combined-stream": {
-                      "version": "0.0.7",
-                      "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
-                      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
-                      "dependencies": {
-                        "delayed-stream": {
-                          "version": "0.0.5",
-                          "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
-                          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
-                        }
-                      }
-                    },
-                    "mime-types": {
-                      "version": "2.0.14",
-                      "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
-                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
-                      "dependencies": {
-                        "mime-db": {
-                          "version": "1.12.0",
-                          "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz",
-                          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "readable-stream": {
-                  "version": "1.0.27-1",
-                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.27-1.tgz",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.27-1.tgz",
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.2",
-                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                    },
-                    "isarray": {
-                      "version": "0.0.1",
-                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31",
-                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                    },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "superagent-hawk": {
-              "version": "0.0.6",
-              "from": "https://registry.npmjs.org/superagent-hawk/-/superagent-hawk-0.0.6.tgz",
-              "resolved": "https://registry.npmjs.org/superagent-hawk/-/superagent-hawk-0.0.6.tgz",
-              "dependencies": {
-                "hawk": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/hawk/-/hawk-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.0.0.tgz",
-                  "dependencies": {
-                    "hoek": {
-                      "version": "0.9.1",
-                      "from": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz",
-                      "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
-                    },
-                    "boom": {
-                      "version": "0.4.2",
-                      "from": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz",
-                      "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
-                    },
-                    "cryptiles": {
-                      "version": "0.2.2",
-                      "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz",
-                      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
-                    },
-                    "sntp": {
-                      "version": "0.2.4",
-                      "from": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz",
-                      "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
-                    }
-                  }
-                },
-                "qs": {
-                  "version": "0.6.6",
-                  "from": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz",
-                  "resolved": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz"
-                }
-              }
-            },
-            "amqplib": {
-              "version": "0.4.2",
-              "from": "https://registry.npmjs.org/amqplib/-/amqplib-0.4.2.tgz",
-              "resolved": "https://registry.npmjs.org/amqplib/-/amqplib-0.4.2.tgz",
-              "dependencies": {
-                "bitsyntax": {
-                  "version": "0.0.4",
-                  "from": "https://registry.npmjs.org/bitsyntax/-/bitsyntax-0.0.4.tgz",
-                  "resolved": "https://registry.npmjs.org/bitsyntax/-/bitsyntax-0.0.4.tgz"
-                },
-                "buffer-more-ints": {
-                  "version": "0.0.2",
-                  "from": "https://registry.npmjs.org/buffer-more-ints/-/buffer-more-ints-0.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/buffer-more-ints/-/buffer-more-ints-0.0.2.tgz"
-                },
-                "readable-stream": {
-                  "version": "1.1.14",
-                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.2",
-                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                    },
-                    "isarray": {
-                      "version": "0.0.1",
-                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31",
-                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                    },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                    }
-                  }
-                },
-                "when": {
-                  "version": "3.6.4",
-                  "from": "https://registry.npmjs.org/when/-/when-3.6.4.tgz",
-                  "resolved": "https://registry.npmjs.org/when/-/when-3.6.4.tgz"
-                }
-              }
-            },
-            "promise": {
-              "version": "6.1.0",
-              "from": "https://registry.npmjs.org/promise/-/promise-6.1.0.tgz",
-              "resolved": "https://registry.npmjs.org/promise/-/promise-6.1.0.tgz",
-              "dependencies": {
-                "asap": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/asap/-/asap-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/asap/-/asap-1.0.0.tgz"
-                }
-              }
-            },
-            "hawk": {
-              "version": "2.3.1",
-              "from": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
-              "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
-              "dependencies": {
-                "hoek": {
-                  "version": "2.16.3",
-                  "from": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
-                },
-                "boom": {
-                  "version": "2.10.1",
-                  "from": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-                  "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
-                },
-                "cryptiles": {
-                  "version": "2.0.5",
-                  "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
-                },
-                "sntp": {
-                  "version": "1.0.9",
-                  "from": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
-                }
-              }
-            },
-            "url-join": {
-              "version": "0.0.1",
-              "from": "https://registry.npmjs.org/url-join/-/url-join-0.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/url-join/-/url-join-0.0.1.tgz"
-            },
-            "sockjs-client": {
-              "version": "1.1.1",
-              "from": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.1.1.tgz",
-              "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.1.1.tgz",
-              "dependencies": {
-                "eventsource": {
-                  "version": "0.1.6",
-                  "from": "https://registry.npmjs.org/eventsource/-/eventsource-0.1.6.tgz",
-                  "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-0.1.6.tgz",
-                  "dependencies": {
-                    "original": {
-                      "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/original/-/original-1.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/original/-/original-1.0.0.tgz",
-                      "dependencies": {
-                        "url-parse": {
-                          "version": "1.0.5",
-                          "from": "https://registry.npmjs.org/url-parse/-/url-parse-1.0.5.tgz",
-                          "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.0.5.tgz",
-                          "dependencies": {
-                            "querystringify": {
-                              "version": "0.0.4",
-                              "from": "https://registry.npmjs.org/querystringify/-/querystringify-0.0.4.tgz",
-                              "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-0.0.4.tgz"
-                            },
-                            "requires-port": {
-                              "version": "1.0.0",
-                              "from": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-                              "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "faye-websocket": {
-                  "version": "0.11.0",
-                  "from": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.0.tgz",
-                  "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.0.tgz",
-                  "dependencies": {
-                    "websocket-driver": {
-                      "version": "0.6.5",
-                      "from": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.6.5.tgz",
-                      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.6.5.tgz",
-                      "dependencies": {
-                        "websocket-extensions": {
-                          "version": "0.1.1",
-                          "from": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.1.tgz",
-                          "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.1.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                },
-                "json3": {
-                  "version": "3.3.2",
-                  "from": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
-                  "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz"
-                },
-                "url-parse": {
-                  "version": "1.1.3",
-                  "from": "https://registry.npmjs.org/url-parse/-/url-parse-1.1.3.tgz",
-                  "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.1.3.tgz",
-                  "dependencies": {
-                    "querystringify": {
-                      "version": "0.0.4",
-                      "from": "https://registry.npmjs.org/querystringify/-/querystringify-0.0.4.tgz",
-                      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-0.0.4.tgz"
-                    },
-                    "requires-port": {
-                      "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz"
-                    }
-                  }
-                }
-              }
+              "version": "2.0.3",
+              "from": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
+              "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz"
             }
           }
         },
@@ -7867,9 +7462,9 @@
                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                         },
                         "inherits": {
-                          "version": "2.0.1",
-                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                          "version": "2.0.3",
+                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                         }
                       }
                     }
@@ -7913,14 +7508,14 @@
                   "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
                   "dependencies": {
                     "is-finite": {
-                      "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                      "version": "1.0.2",
+                      "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+                      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
                       "dependencies": {
                         "number-is-nan": {
-                          "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
-                          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                          "version": "1.0.1",
+                          "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
                         }
                       }
                     }
@@ -8008,36 +7603,36 @@
                       "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
                       "dependencies": {
                         "inflight": {
-                          "version": "1.0.4",
-                          "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-                          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                          "version": "1.0.5",
+                          "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
+                          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
                           "dependencies": {
                             "wrappy": {
-                              "version": "1.0.1",
-                              "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
-                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                              "version": "1.0.2",
+                              "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                             }
                           }
                         },
                         "inherits": {
-                          "version": "2.0.1",
-                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                          "version": "2.0.3",
+                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                         },
                         "minimatch": {
-                          "version": "3.0.0",
-                          "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
-                          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                          "version": "3.0.3",
+                          "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+                          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
                           "dependencies": {
                             "brace-expansion": {
-                              "version": "1.1.4",
-                              "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.4.tgz",
-                              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.4.tgz",
+                              "version": "1.1.6",
+                              "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
+                              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
                               "dependencies": {
                                 "balanced-match": {
-                                  "version": "0.4.1",
-                                  "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.1.tgz",
-                                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.1.tgz"
+                                  "version": "0.4.2",
+                                  "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+                                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
                                 },
                                 "concat-map": {
                                   "version": "0.0.1",
@@ -8049,28 +7644,28 @@
                           }
                         },
                         "once": {
-                          "version": "1.3.3",
-                          "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-                          "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                          "version": "1.4.0",
+                          "from": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+                          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
                           "dependencies": {
                             "wrappy": {
-                              "version": "1.0.1",
-                              "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
-                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                              "version": "1.0.2",
+                              "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                             }
                           }
                         },
                         "path-is-absolute": {
-                          "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
-                          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                          "version": "1.0.1",
+                          "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
                         }
                       }
                     },
                     "graceful-fs": {
-                      "version": "4.1.3",
-                      "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz",
-                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
+                      "version": "4.1.9",
+                      "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
+                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz"
                     },
                     "iconv-lite": {
                       "version": "0.4.13",
@@ -8131,9 +7726,9 @@
                   }
                 },
                 "regenerate": {
-                  "version": "1.2.1",
-                  "from": "https://registry.npmjs.org/regenerate/-/regenerate-1.2.1.tgz",
-                  "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.2.1.tgz"
+                  "version": "1.3.1",
+                  "from": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.1.tgz",
+                  "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.1.tgz"
                 },
                 "regjsgen": {
                   "version": "0.2.0",
@@ -8328,9 +7923,9 @@
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "inherits": {
-                  "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                  "version": "2.0.3",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                 }
               }
             }
@@ -8366,9 +7961,9 @@
       "resolved": "https://registry.npmjs.org/websocket-stream/-/websocket-stream-2.3.0.tgz",
       "dependencies": {
         "duplexify": {
-          "version": "3.4.3",
-          "from": "https://registry.npmjs.org/duplexify/-/duplexify-3.4.3.tgz",
-          "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.4.3.tgz",
+          "version": "3.4.5",
+          "from": "https://registry.npmjs.org/duplexify/-/duplexify-3.4.5.tgz",
+          "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.4.5.tgz",
           "dependencies": {
             "end-of-stream": {
               "version": "1.0.0",
@@ -8381,19 +7976,24 @@
                   "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                   "dependencies": {
                     "wrappy": {
-                      "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                      "version": "1.0.2",
+                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                     }
                   }
                 }
               }
             },
             "readable-stream": {
-              "version": "2.1.2",
-              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.2.tgz",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.2.tgz",
+              "version": "2.1.5",
+              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
               "dependencies": {
+                "buffer-shims": {
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
+                },
                 "core-util-is": {
                   "version": "1.0.2",
                   "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -8405,9 +8005,9 @@
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                 },
                 "process-nextick-args": {
-                  "version": "1.0.6",
-                  "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
-                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
+                  "version": "1.0.7",
+                  "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
@@ -8420,13 +8020,18 @@
                   "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                 }
               }
+            },
+            "stream-shift": {
+              "version": "1.0.0",
+              "from": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz"
             }
           }
         },
         "inherits": {
-          "version": "2.0.1",
-          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+          "version": "2.0.3",
+          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
         },
         "through2": {
           "version": "2.0.1",
@@ -8449,9 +8054,9 @@
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                 },
                 "process-nextick-args": {
-                  "version": "1.0.6",
-                  "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
-                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
+                  "version": "1.0.7",
+                  "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
@@ -8500,9 +8105,9 @@
               "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz"
             },
             "nan": {
-              "version": "2.3.2",
-              "from": "https://registry.npmjs.org/nan/-/nan-2.3.2.tgz",
-              "resolved": "https://registry.npmjs.org/nan/-/nan-2.3.2.tgz"
+              "version": "2.4.0",
+              "from": "https://registry.npmjs.org/nan/-/nan-2.4.0.tgz",
+              "resolved": "https://registry.npmjs.org/nan/-/nan-2.4.0.tgz"
             }
           }
         },
@@ -8517,18 +8122,18 @@
               "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz"
             },
             "nan": {
-              "version": "2.3.2",
-              "from": "https://registry.npmjs.org/nan/-/nan-2.3.2.tgz",
-              "resolved": "https://registry.npmjs.org/nan/-/nan-2.3.2.tgz"
+              "version": "2.4.0",
+              "from": "https://registry.npmjs.org/nan/-/nan-2.4.0.tgz",
+              "resolved": "https://registry.npmjs.org/nan/-/nan-2.4.0.tgz"
             }
           }
         }
       }
     },
     "xml2js": {
-      "version": "0.4.16",
-      "from": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.16.tgz",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.16.tgz",
+      "version": "0.4.17",
+      "from": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.17.tgz",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.17.tgz",
       "dependencies": {
         "sax": {
           "version": "1.2.1",
@@ -8541,9 +8146,9 @@
           "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.2.1.tgz",
           "dependencies": {
             "lodash": {
-              "version": "4.11.2",
-              "from": "https://registry.npmjs.org/lodash/-/lodash-4.11.2.tgz",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.11.2.tgz"
+              "version": "4.16.3",
+              "from": "https://registry.npmjs.org/lodash/-/lodash-4.16.3.tgz",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.3.tgz"
             }
           }
         }

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "tar-stream": "^1.2.1",
     "taskcluster-azure-blobstream": "^0.3.0",
     "taskcluster-base": "^0.13.0",
-    "taskcluster-client": "^0.22.0",
+    "taskcluster-client": "^1.4.0",
     "taskcluster-lib-monitor": "^4.2.0",
     "taskcluster-task-factory": "^0.6.1",
     "temporary": "0.0.8",

--- a/test/integration/capacity_test.js
+++ b/test/integration/capacity_test.js
@@ -47,12 +47,7 @@ suite('Capacity', function() {
         diskspaceThreshold: 1
       },
       taskQueue: {
-        // Make the poll very high so that once tasks start, it will not
-        // poll again to interupt the event loop
-        pollInterval: 30 * 1000,
-        expiration: 5 * 60 * 1000,
-        maxRetries: 5,
-        requestRetryInterval: 2 * 1000
+        pollInterval: 1000
       }
     });
 

--- a/test/integration/capacity_test.js
+++ b/test/integration/capacity_test.js
@@ -89,7 +89,7 @@ suite('Capacity', function() {
 
     // Wait for the first claim to start timing.  This weeds out any issues with
     // waiting for the task queue to be polled
-    yield waitForEvent(worker, 'claim task');
+    yield waitForEvent(worker, 'claimed task');
     var start = Date.now();
 
     var results = yield tasks;

--- a/test/integration/registry_auth_test.js
+++ b/test/integration/registry_auth_test.js
@@ -69,7 +69,6 @@ suite('Docker custom private registry', () => {
         maxRunTime: 60 * 60
       }
     });
-    console.log(result.log);
     assert.equal(result.run.state, 'completed', 'auth download works');
     assert.equal(result.run.reasonResolved, 'completed', 'auth download works');
     assert.ok(result.log.includes(registryImageName), 'correct image name');
@@ -146,7 +145,6 @@ suite('Docker custom private registry', () => {
 
     assert.equal(result.run.state, 'failed', 'auth download works');
     assert.equal(result.run.reasonResolved, 'failed', 'auth download works');
-    assert.ok(result.log.includes(registryImageName), 'correct image name');
     assert.ok(result.log.includes(`image ${REPO_IMAGE_NAME.replace(':latest', '')} not found`), 'authorization failed');
   });
 });

--- a/test/integration/spot_node_termination_test.js
+++ b/test/integration/spot_node_termination_test.js
@@ -130,10 +130,7 @@ suite('Spot Node Termination', () => {
   test('task is not claimed on startup if node terminated', async () => {
     settings.configure({
       taskQueue: {
-        pollInterval: 500,
-        expiration: 5 * 60 * 1000,
-        maxRetries: 5,
-        requestRetryInterval: 2 * 1000
+        pollInterval: 500
       },
       shutdown: {
         enabled: true,


### PR DESCRIPTION
Okay, this is more of a "I have no clue what I'm doing -- have look maybe this works" kind of hack...

I would love for us to try and use `queue.claimWork` in production with docker-worker. Ideally, we can try it for a high volume workerType before we roll it out to everything.

But I would really like to get some load on this, so we can show that it works and that our heroku nodes won't fallover from having to do so much polling work... Hopefully it works, if it doesn't we might have to roll back, so we should have old AMIs handy when we try this out.

I suspect tests will fail as the scope `queue:claim-work:<provisionerId>/<workerType>` is required for `queue.claimWork`.