### PR TITLE
Env vars should always be strings

### DIFF
--- a/schemas/payload.json
+++ b/schemas/payload.json
@@ -195,9 +195,12 @@
       }
     },
     "env": {
-      "title": "Environment variable mappings.",
+      "title": "Environment variable mappings. Must be strings.",
       "description": "Example: ```\n{\n  \"PATH\": '/borked/path' \n  \"ENV_NAME\": \"VALUE\" \n}\n```",
-      "type": "object"
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
     },
     "maxRunTime": {
       "type": "number",


### PR DESCRIPTION
This avoids unexpected translations.

Example:

```
"Height": 1.95
```

could result in the env variable `Height` having value `1.95` or `1,95` depending on locale. Similarly, `1000000000` might be represented as `1,000,000,000` or `1E9` or `1.000E9` as a string, depending on how the worker translates numbers to strings. Since env vars are necessarily strings, it is not easy to know how they will get translated.

Lastly, how would `"ENV_X": { "A": "B" }` be interpreted as the environment variable `ENV_X`? It is not easy to say. Maybe raw json?

Enforcing that env vars are specified as strings avoids this ambiguity, and strange bugs arising as a result of an unexpected conversion, in rare edge cases.