### PR TITLE
Improved error message

### DIFF
--- a/lib/docker/artifact_image.js
+++ b/lib/docker/artifact_image.js
@@ -136,7 +136,7 @@ export default class ArtifactImage {
           tarballPath = downloadedFile;
           break;
         default:
-          throw new Error('Unsupported image file format. Expected tarball with optional lz4 compression');
+          throw new Error('Unsupported image file format. Expected tarball with extension: .tar.zst, .tar.lz4 or .tar');
       }
 
       await this.renameAndLoad(this.imageName, tarballPath);


### PR DESCRIPTION
Found this when I used `.tar.zstd` instead of `.tar.zst` my bad...

No need to rebuild AMIs, I'm happy if this comes out whenever we roll the next update..