### PR TITLE
Fix issues with initializing sidecar containers

### DIFF
--- a/lib/docker/docker_image.js
+++ b/lib/docker/docker_image.js
@@ -105,12 +105,12 @@ export default class DockerImage {
 
     while (attempts++ < config.maxAttempts) {
       debug('pull image. Image: %s Attempts: %s', image, attempts);
-      let downloadProgress =
-        dockerUtils.pullImageIfMissing(docker, image, options);
-
-      downloadProgress.pipe(stream, {end: false});
 
       try {
+        let downloadProgress =
+          dockerUtils.pullImageIfMissing(docker, image, options);
+
+        downloadProgress.pipe(stream, {end: false});
         await new Promise((accept, reject) => {
           downloadProgress.once('error', reject);
           downloadProgress.once('end', accept);


### PR DESCRIPTION
Move the download progress initialization to a try/catch block to ensure
that any errors will be caught and retried.