### PR TITLE
Use livelog v4

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -54,7 +54,7 @@ defaults:
 
   # Image used to  create the taskcluster proxy container.
   taskclusterProxyImage: 'taskcluster/taskcluster-proxy:latest'
-  taskclusterLogImage: 'taskcluster/livelog:v3'
+  taskclusterLogImage: 'taskcluster/livelog:v4'
   testdroidProxyImage: 'taskcluster/testdroid-proxy:0.0.7'
   balrogVPNProxyImage: 'taskclusterprivate/taskcluster-vpn-proxy:0.0.3'
   dindImage: 'taskcluster/dind-service:v4.0'


### PR DESCRIPTION
This allows cors requests to see transfer-encoding... so logviewer can detect that the log is live.