### PR TITLE
Added hooks for idle work...

### DIFF
--- a/src/lib/docker/docker_image.js
+++ b/src/lib/docker/docker_image.js
@@ -58,7 +58,7 @@ export default class DockerImage {
 
     // See if any credentials apply from our list of registries...
     let defaultRegistry = this.runtime.dockerConfig.defaultRegistry;
-    this.credentials = this.getCredentials(this.runtime.registries, defaultRegistry);
+    this.credentials = getCredentials(this.name, this.runtime.registries, defaultRegistry);
 
     if (!this.credentials) {
       return true;
@@ -169,38 +169,39 @@ export default class DockerImage {
     return components.length === 2 || components.length === 3;
   }
 
-  /**
-  Attempt to find credentials from within an object of repositories.
+}
 
-  @return {Object|null} credentials or null...
-  */
-  getCredentials(repositories, defaultRegistry='') {
-    // We expect the image to be be checked via imageCanAuthenticate first.
-    // This could be user/image or host/user/image.  If only user/image, use
-    // default registry
-    var parts = this.name.split('/');
-    if (parts.length === 2) parts.unshift(defaultRegistry);
+/**
+Attempt to find credentials from within an object of repositories.
 
-    var registryHost = parts[0];
-    var registryUser = parts[1];
-    var result;
+@return {Object|null} credentials or null...
+*/
+export function getCredentials(name, repositories, defaultRegistry='') {
+  // We expect the image to be be checked via imageCanAuthenticate first.
+  // This could be user/image or host/user/image.  If only user/image, use
+  // default registry
+  var parts = name.split('/');
+  if (parts.length === 2) parts.unshift(defaultRegistry);
 
-    // Note this may search through all repositories intentionally as to only
-    // match the correct (longest match based on slashes).
-    for (var registry in repositories) {
+  var registryHost = parts[0];
+  var registryUser = parts[1];
+  var result;
 
-      // Longest possible match always wins fast path return...
-      if (registryHost + '/' + registryUser === registry) {
-        return repositories[registry];
-      }
+  // Note this may search through all repositories intentionally as to only
+  // match the correct (longest match based on slashes).
+  for (var registry in repositories) {
 
-      // Hold on to partial matches but we cannot use these as the final values
-      // without exhausting all options...
-      if (registryHost + '/' === registry || registryHost === registry) {
-        result = repositories[registry];
-      }
+    // Longest possible match always wins fast path return...
+    if (registryHost + '/' + registryUser === registry) {
+      return repositories[registry];
     }
 
-    return result;
+    // Hold on to partial matches but we cannot use these as the final values
+    // without exhausting all options...
+    if (registryHost + '/' === registry || registryHost === registry) {
+      result = repositories[registry];
+    }
   }
+
+  return result;
 }

--- a/src/lib/idlework.js
+++ b/src/lib/idlework.js
@@ -1,6 +1,8 @@
 import dockerUtils from 'dockerode-process/utils';
 import devnull from 'dev-null';
 import { getCredentials } from './docker/docker_image';
+import Debug from 'debug';
+
 const debug = Debug('docker-worker:idle-work');
 
 export default class IdleWork {

--- a/src/lib/idlework.js
+++ b/src/lib/idlework.js
@@ -39,10 +39,20 @@ export default class IdleWork {
 
   async run() {
     let aborting = false;
-    // Pull image for idle work
     this.abort = () => {
       aborting = true;
     };
+
+    // Sleep for 45s before we start idle-work
+    await new Promise(resolve => setTimeout(resolve, 45 * 1000));
+    // Abort, if asked to do so...
+    if (aborting) {
+      this.done = null;
+      this.abort = () => {};
+      return;
+    }
+
+    // Pull image for idle work
     let downloadProgress = dockerUtils.pullImageIfMissing(
     this.runtime.docker, this.runtime.idleImage, {
       retryConfig: this.runtime.dockerConfig,
@@ -56,6 +66,8 @@ export default class IdleWork {
 
     // Abort, if asked to do so...
     if (aborting) {
+      this.done = null;
+      this.abort = () => {};
       return;
     }
 

--- a/src/lib/idlework.js
+++ b/src/lib/idlework.js
@@ -1,0 +1,115 @@
+import dockerUtils from 'dockerode-process/utils';
+import devnull from 'dev-null';
+import { getCredentials } from './docker/docker_image';
+const debug = Debug('docker-worker:idle-work');
+
+export default class IdleWork {
+  constructor(runtime) {
+    this.runtime = runtime;
+    this.done = null;
+    this.abort = () => {};
+  }
+
+  async start() {
+    // Do nothing, if we don't have an idle image
+    if (!this.runtime.idleImage) {
+      return;
+    }
+
+    if (!this.done) {
+      this.abort = () => {};
+      this.done = this.run();
+    }
+  }
+
+  async stop() {
+    if (this.done) {
+      if (this.abort) {
+        try {
+          this.abort();
+        } catch(err) {
+          debug('error aborting idle work, error: ', err)
+        }
+        this.abort = null;
+      }
+      await this.done.catch(err => debug('error from idle-work, error: ', err));
+      this.done = null;
+    }
+  }
+
+  async run() {
+    let aborting = false;
+    // Pull image for idle work
+    this.abort = () => {
+      aborting = true;
+    };
+    let downloadProgress = dockerUtils.pullImageIfMissing(
+    this.runtime.docker, this.runtime.idleImage, {
+      retryConfig: this.runtime.dockerConfig,
+      authconfig:  getCredentials(this.runtime.idleImage, this.runtime.registries, this.runtime.dockerConfig.defaultRegistry),
+    });
+    downloadProgress.pipe(devnull(), {end: false});
+    await new Promise((accept, reject) => {
+      downloadProgress.once('error', reject);
+      downloadProgress.once('end', accept);
+    });
+
+    // Abort, if asked to do so...
+    if (aborting) {
+      return;
+    }
+
+    let idleProcess = new DockerProc(this.runtime.docker, {
+      start: {},
+      create: {
+        Image: image.Id,
+        AttachStdin: false,
+        AttachStdout: false,
+        AttachStderr: false,
+        Tty: false,
+        OpenStdin: false,
+        StdinOnce: false,
+        HostConfig: {
+          ShmSize: 1800000000
+        }
+      }
+    });
+
+    let aborted = false;
+    let abort = this.abort = async () => {
+      if (aborted) {
+        return;
+      }
+      aborted = true;
+      try {
+        await idleProcess.kill();
+      } catch(err) {
+        debug("error while killing idle container: %s", err);
+      }
+    }
+
+    // Run the idle container
+    try {
+      let exitCode = await idleProcess.run({pull: false});
+      if (exitCode !== 0) {
+        debug("idle container exited non-zero: %d", exitCode);
+      }
+    } catch(err) {
+      debug("error trying to run idle container: %s", err);
+    }
+
+    // Remove container
+    try {
+      await this.docker.getContainer(idleProcess.container.id).remove({
+        force: true,
+        v: true,
+      });
+    } catch(err) {
+      debug("error while removing idle container: %s", err);
+    }
+
+    // Cleanup state
+    this.done = null;
+    this.abort = () => {};
+  }
+}

--- a/src/lib/task_listener.js
+++ b/src/lib/task_listener.js
@@ -10,6 +10,7 @@ import request from 'superagent-promise';
 import { Task } from './task';
 import { EventEmitter } from 'events';
 import { exceedsDiskspaceThreshold } from './util/capacity';
+import IdleWork from './idlework';
 
 const debug = Debug('docker-worker:task-listener');
 
@@ -39,6 +40,7 @@ export default class TaskListener extends EventEmitter {
     );
     this.capacityMonitor = this.runtime.workerTypeMonitor.prefix('capacity');
     this.deviceManager = new DeviceManager(runtime);
+    this.idleWork = new IdleWork(runtime);
   }
 
   listenForShutdowns() {
@@ -585,11 +587,11 @@ export default class TaskListener extends EventEmitter {
 
   /** Start idle work, if not running */
   startIdleWork() {
-
+    this.idlework.start();
   }
 
   /** Stop idle work, if running */
   async stopIdleWork() {
-
+    await this.idlework.stop();
   }
 }


### PR DESCRIPTION
Do we agree that `startIdleWork` and `stopIdleWork` is called in the right places?

Worker will block the next task until `stopIdleWork` is done... and `startIdleWork` will be called whenever we're idle, so if idle work isn't running it can start it... and it can measure that it's been idle for 2 min before starting idle work too... etc...

Agree, that this is what we need to fit the logic into? Or are we missing some hooks, are we not blocking correctly before running new tasks? or something else I'm missing... I think I managed to ensure `stopIdleWork` gets called when we shutdown...