### PR TITLE
vagrant: Fix development environment.

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ an environment very similar to the one docker-worker runs in production.
 2. The tests require TASKCLUSTER_ACCESS_TOKEN, TASKCLUSTER_CLIENT_ID, PULSE_USERNAME, PULSE_PASSWORD to be setup within the environment.  If they were not available locally when building, add them to the virtual machine now.
 3. `cd /vagrant` # Your local checkout of the docker-worker repo is made available under the '/vagrant' directory
 4. `./build.sh` # Builds some of the test images that are required
-5. `yarn install` # Installs all the necessary node modules
+5. `yarn install --frozen-lockfile` # Installs all the necessary node modules
 
 #### Running Tests
 

--- a/vagrant.sh
+++ b/vagrant.sh
@@ -73,7 +73,7 @@ cd /usr/local/ && \
   node -v
 
 # Install some necessary node packages
-npm install -g yarn
+npm install -g yarn babel-cli
 
 # Install Video loopback devices
 sudo apt-get install -y \


### PR DESCRIPTION
babel-cli is a dependency for running tests and "yarn install" should
use --frozen-lockfile to avoid updating dependencies.