### PR TITLE
Do not use primary task credentials when resolving superseded task

### DIFF
--- a/src/lib/task.js
+++ b/src/lib/task.js
@@ -221,7 +221,7 @@ export class Reclaimer {
     this.log('reclaiming task');
 
     try {
-      let queue = this.task.createQueue(this.claim.credentials, this.runtime);
+      let queue = this.task.createQueue(this.claim.credentials);
       this.claim = await queue.reclaimTask(
                     this.claim.status.taskId, this.claim.runId);
       // reclaim does not return the task, so carry that forward from the previous
@@ -252,7 +252,7 @@ export class Reclaimer {
     }
 
     if (this.claim.status.taskId == this.primaryClaim.status.taskId) {
-      this.task.queue = this.task.createQueue(this.claim.credentials, this.runtime);
+      this.task.queue = this.task.createQueue(this.claim.credentials);
       this.task.emit('credentials', this.claim.credentials);
     }
 
@@ -290,7 +290,7 @@ export class Task extends EventEmitter {
     this.taskState = 'pending';
     this.options = options;
 
-    this.queue = this.createQueue(this.claim.credentials, runtime);
+    this.queue = this.createQueue(this.claim.credentials);
 
     // Primarly log of all actions for the task.
     this.stream = new PassThrough();
@@ -618,7 +618,7 @@ export class Task extends EventEmitter {
     let supersedes = [];
     let log = this.runtime.log;
 
-    await Promise.all(this.claims.map(async function(c){
+    await Promise.all(this.claims.map(async (c) => {
       let taskId = c.status.taskId;
       let runId = c.runId;
       if (taskId == primaryTaskId && runId == primaryRunId) {
@@ -1012,7 +1012,7 @@ export class Task extends EventEmitter {
 
   @return New queue.
   */
-  createQueue(credentials, runtime) {
+  createQueue(credentials) {
     return new taskcluster.Queue({
       credentials: credentials,
     });

--- a/src/lib/task.js
+++ b/src/lib/task.js
@@ -619,13 +619,13 @@ export class Task extends EventEmitter {
     let log = this.runtime.log;
 
     await Promise.all(this.claims.map(async function(c){
-      try {
-        let taskId = c.status.taskId;
-        let runId = c.runId;
-        if (taskId == primaryTaskId && runId == primaryRunId) {
-          return;
-        }
+      let taskId = c.status.taskId;
+      let runId = c.runId;
+      if (taskId == primaryTaskId && runId == primaryRunId) {
+        return;
+      }
 
+      try {
         let queue = this.createQueue(c.credentials);
         await queue.reportException(taskId, runId, {reason});
 

--- a/src/lib/task.js
+++ b/src/lib/task.js
@@ -615,7 +615,6 @@ export class Task extends EventEmitter {
    */
 
   async resolveSuperseded(primaryTaskId, primaryRunId, addArtifacts, reason) {
-    let queue = this.queue;
     let supersedes = [];
     let log = this.runtime.log;
 
@@ -627,6 +626,7 @@ export class Task extends EventEmitter {
           return;
         }
 
+        let queue = this.createQueue(c.credentials);
         await queue.reportException(taskId, runId, {reason});
 
         if (addArtifacts) {
@@ -660,7 +660,7 @@ export class Task extends EventEmitter {
       let task = this.claim.task;
       let expiration = task.expires || taskcluster.fromNow(task.deadline, "1 year");
       let contentJson = JSON.stringify(supersedes)
-      await uploadToS3(queue, primaryTaskId, primaryRunId, contentJson,
+      await uploadToS3(this.queue, primaryTaskId, primaryRunId, contentJson,
                        "public/supersedes.json", expiration, {
         'content-type': 'application/json',
         'content-length': contentJson.length,


### PR DESCRIPTION
This should fix resolving superseded tasks.  Currently without the fix, a scope error will be thrown because the queue client being used is for the primary task which does not have scopes to resolve the superseded task.