### PR TITLE
Fix json schema to use "format": "uri" rather than "url"

### DIFF
--- a/schemas/payload.json
+++ b/schemas/payload.json
@@ -242,7 +242,7 @@
     "supersederUrl": {
       "title": "URL of the a service that can indicate tasks superseding this one; the current taskId will be appended as a query argument `taskId`.  The service should return an object with a `supersedes` key containing a list of taskIds, including the supplied taskId.  The tasks should be ordered such that each task supersedes all tasks appearing earlier in the list.  See the docker-worker documentation for more detail.",
       "type": "string",
-      "format": "url"
+      "format": "uri"
     },
     "features": {
       "title": "Feature flags",


### PR DESCRIPTION
Just a minor papercut. See [logs](https://papertrailapp.com/groups/853883/events?q=unknown%20format%20%22url%22%20ignored%20in%20schema%20at%20path) and [json schema validation specification](http://json-schema.org/latest/json-schema-validation.html#rfc.section.8.3.6).