### PR TITLE
Update taskcluster proxy image to 4.0.0

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -53,7 +53,7 @@ defaults:
   restrictCPU: false
 
   # Image used to  create the taskcluster proxy container.
-  taskclusterProxyImage: 'taskcluster/taskcluster-proxy:latest'
+  taskclusterProxyImage: 'taskcluster/taskcluster-proxy:4.0.0'
   taskclusterLogImage: 'taskcluster/livelog:v4'
   testdroidProxyImage: 'taskcluster/testdroid-proxy:0.0.7'
   balrogVPNProxyImage: 'taskclusterprivate/taskcluster-vpn-proxy:0.0.3'

--- a/deploy/packer/app/scripts/deploy.sh
+++ b/deploy/packer/app/scripts/deploy.sh
@@ -39,13 +39,13 @@ sudo modprobe snd-aloop
 sudo depmod
 
 # Pull images used for sidecar containers
-docker pull taskcluster/taskcluster-proxy:latest
+docker pull taskcluster/taskcluster-proxy:4.0.0
 docker pull taskcluster/livelog:v4
 docker pull taskcluster/dind-service:v4.0
 docker pull taskcluster/relengapi-proxy:2.1.1
 
 # Export the images as a tarball to load when insances are initialized
-docker save taskcluster/taskcluster-proxy:latest taskcluster/livelog:v4 taskcluster/dind-service:v4.0 taskcluster/relengapi-proxy:2.1.1 > /home/ubuntu/docker_worker/docker_worker_images.tar
+docker save taskcluster/taskcluster-proxy:4.0.0 taskcluster/livelog:v4 taskcluster/dind-service:v4.0 taskcluster/relengapi-proxy:2.1.1 > /home/ubuntu/docker_worker/docker_worker_images.tar
 
 # Generate enough entropy to allow for gpg key generation
 sudo rngd -r /dev/urandom

--- a/src/lib/features/taskcluster_proxy.js
+++ b/src/lib/features/taskcluster_proxy.js
@@ -38,7 +38,7 @@ export default class TaskclusterProxy {
         cmd.push('--certificate=' + task.claim.credentials.certificate);
     }
     const cert = JSON.parse(task.claim.credentials.certificate);
-    cmd.push(task.status.taskId);
+    cmd.push(`--task-id=${task.status.taskId}`);
     cmd = cmd.concat(cert.scopes);
 
     // create the container.


### PR DESCRIPTION
In addition to bumping version, the command passed into taskcluster proxy has changed to explicitly declare what is the task ID.