### PR TITLE
Bug 1394358 - revert upgrade to relengapi-proxy 2.1.1 which does not work

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -31,7 +31,7 @@ defaults:
     randomizationFactor: 0.25
   features:
     relengAPIProxy:
-      image: 'taskcluster/relengapi-proxy:2.1.1'
+      image: 'taskcluster/relengapi-proxy:2.0.1'
       token: !env RELENG_API_TOKEN
   ssl:
     certificate: '/etc/star_taskcluster-worker_net.crt'

--- a/deploy/packer/app/scripts/deploy.sh
+++ b/deploy/packer/app/scripts/deploy.sh
@@ -42,10 +42,10 @@ sudo depmod
 docker pull taskcluster/taskcluster-proxy:4.0.0
 docker pull taskcluster/livelog:v4
 docker pull taskcluster/dind-service:v4.0
-docker pull taskcluster/relengapi-proxy:2.1.1
+docker pull taskcluster/relengapi-proxy:2.0.1
 
 # Export the images as a tarball to load when insances are initialized
-docker save taskcluster/taskcluster-proxy:4.0.0 taskcluster/livelog:v4 taskcluster/dind-service:v4.0 taskcluster/relengapi-proxy:2.1.1 > /home/ubuntu/docker_worker/docker_worker_images.tar
+docker save taskcluster/taskcluster-proxy:4.0.0 taskcluster/livelog:v4 taskcluster/dind-service:v4.0 taskcluster/relengapi-proxy:2.0.1 > /home/ubuntu/docker_worker/docker_worker_images.tar
 
 # Generate enough entropy to allow for gpg key generation
 sudo rngd -r /dev/urandom


### PR DESCRIPTION
Rok is going to be away all September, so let's roll back this change so it doesn't mess up any releases we might need to make before relengapi-proxy is fixed.