### PR TITLE
[test] Fix lz4 image artifact script. r=garndt

### DIFF
--- a/test/fixtures/image_artifacts.js
+++ b/test/fixtures/image_artifacts.js
@@ -10,7 +10,7 @@ export const TASK_IMAGE_ARTIFACT_HASH = 'sha256:0d79355a83063d592285e529460af86e
 export const TASK_IMAGE_HASH = 'sha256:dcf5b7936f77be812c8a17ba8284d198e3afcf57fb11bb2ab4311a511bf95f39';
 
 // LZ4 compressed image
-export const LZ4_TASK_ID = 'TwSPMBlrRd2VMT6xczLkOA';
+export const LZ4_TASK_ID = 'WG22pWAQTDG-hVTU1IHQdA';
 
 // Zstandard compressed impage
 export const ZSTD_TASK_ID = 'd6hoilN7TduHjBDHPd-JgA';


### PR DESCRIPTION
This is a follow up of the PR #317. If the artifact we are uploading is
too big, we need to periodically reclaim the task or it will resolve
with a task expired exception.