### PR TITLE
Pin yarn to 1.0.2

### DIFF
--- a/deploy/packer/app/scripts/deploy.sh
+++ b/deploy/packer/app/scripts/deploy.sh
@@ -27,7 +27,7 @@ cd $target
 tar xzf $docker_worker_source -C $target --strip-components=1
 sudo chown -R $USER:$USER /home/ubuntu/docker_worker
 
-sudo npm install -g babel-cli yarn
+sudo npm install -g babel-cli yarn@1.0.2
 
 yarn install --frozen-lockfile
 yarn build

--- a/test/images/ci/Dockerfile
+++ b/test/images/ci/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 RUN curl -SL "http://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.gz" | \
     tar xz -C /usr/local --strip-components=1 && \
-    npm install -g babel-cli yarn
+    npm install -g babel-cli yarn@1.0.2
 
 env HOME /home/tester
 env SHELL /bin/bash

--- a/vagrant.sh
+++ b/vagrant.sh
@@ -73,7 +73,7 @@ cd /usr/local/ && \
   node -v
 
 # Install some necessary node packages
-npm install -g yarn babel-cli
+npm install -g yarn@1.0.2 babel-cli
 
 # Install Video loopback devices
 sudo apt-get install -y \


### PR DESCRIPTION
There is an issue with the latest version of yarn, version 1.1.0 where
devDependencies are installed unintentionally.  This happens even when
NODE_ENV=production or passing in `--production` to yarn.  This causes
dockerode-promise to install an older version of dockerode which does
not work with image tags containing a content hash, such as
some-image@sha256:1234.