### PR TITLE
Bug 1405683: Add option to disable worker types backup.

### DIFF
--- a/deploy/bin/update-worker-types.js
+++ b/deploy/bin/update-worker-types.js
@@ -1,15 +1,30 @@
 #!/usr/bin/env node
 
-const workerTypesList = require('../etc/worker-types.json');
+const workerTypesListProd = require('../etc/worker-types.json');
+const workerTypesListTest = require('../etc/worker-types-test.json');
 const amis = require('../../docker-worker-amis.json');
 const jsonfile = require('jsonfile');
 const utils = require('./worker_type_utils');
 const _ = require('lodash');
+const program = require('commander');
+
+program
+  .option('--no-backup', "Don't generate the backup file.")
+  .option('-t, --test', "Update only test worker types.")
+  .parse(process.argv);
+
+const workerTypesList = program.test
+  ? workerTypesListTest
+  : workerTypesListProd;
 
 /*
  * Backup worker-types regions config
  */
 function backupWorkerTypes(client) {
+  if (!program.backup) {
+    return Promise.resolve();
+  }
+
   console.log('Creating worker-types backup file.');
   const names = _.flatten(_.map(workerTypesList, v => v));
   const workerTypes = names.map(name => {

--- a/deploy/etc/worker-types-test.json
+++ b/deploy/etc/worker-types-test.json
@@ -1,0 +1,10 @@
+{
+  "hvm-builder": [
+    "ami-test"
+  ],
+  "hvm-builder-trusted": [
+  ],
+  "pv-builder": [
+    "ami-test-pv"
+  ]
+}

--- a/release.sh
+++ b/release.sh
@@ -20,5 +20,5 @@ fi
 
 deploy/bin/import-docker-worker-secrets
 deploy/bin/build app
-deploy/bin/update-worker-types.js
+deploy/bin/update-worker-types.js $*
 rm -f /tmp/docker-worker*


### PR DESCRIPTION
If, during the process of updating the worker types an update fails, the
worker types set will be left in an in-between state where some are
updated and others not. If we run the script again, backups will be
overwritten with this undesirable state.

We add an option to update-worker-types script to not generate backup
file before updating.