### PR TITLE
Bug 1405889 - Upgrade taskcluster-proxy from 4.0.0 to 4.0.1

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -53,7 +53,7 @@ defaults:
   restrictCPU: false
 
   # Image used to  create the taskcluster proxy container.
-  taskclusterProxyImage: 'taskcluster/taskcluster-proxy:4.0.0'
+  taskclusterProxyImage: 'taskcluster/taskcluster-proxy:4.0.1'
   taskclusterLogImage: 'taskcluster/livelog:v4'
   testdroidProxyImage: 'taskcluster/testdroid-proxy:0.0.7'
   balrogVPNProxyImage: 'taskclusterprivate/taskcluster-vpn-proxy:0.0.3'

--- a/deploy/packer/app/scripts/deploy.sh
+++ b/deploy/packer/app/scripts/deploy.sh
@@ -39,10 +39,10 @@ sudo modprobe snd-aloop
 sudo depmod
 
 # Pull images used for sidecar containers
-docker pull taskcluster/taskcluster-proxy:4.0.0
+docker pull taskcluster/taskcluster-proxy:4.0.1
 docker pull taskcluster/livelog:v4
 docker pull taskcluster/dind-service:v4.0
 docker pull taskcluster/relengapi-proxy:2.0.1
 
 # Export the images as a tarball to load when insances are initialized
-docker save taskcluster/taskcluster-proxy:4.0.0 taskcluster/livelog:v4 taskcluster/dind-service:v4.0 taskcluster/relengapi-proxy:2.0.1 > /home/ubuntu/docker_worker/docker_worker_images.tar
+docker save taskcluster/taskcluster-proxy:4.0.1 taskcluster/livelog:v4 taskcluster/dind-service:v4.0 taskcluster/relengapi-proxy:2.0.1 > /home/ubuntu/docker_worker/docker_worker_images.tar


### PR DESCRIPTION
I've [released](https://hub.docker.com/r/taskcluster/taskcluster-proxy/tags/) taskcluster-proxy 4.0.1 with the [bug 1405889](https://bugzilla.mozilla.org/show_bug.cgi?id=1405889) taskcluster-client-go [fix](https://github.com/taskcluster/taskcluster-client-go/commit/c16489a70a6f20ac72964be79df37753b3fce4d5).