### PR TITLE
Add Balrog stage host/ip to balrogvpnproxy hack.

### DIFF
--- a/src/lib/features/balrog_vpn_proxy.js
+++ b/src/lib/features/balrog_vpn_proxy.js
@@ -77,7 +77,7 @@ export default class BalrogVPNProxy {
         ExtraHosts: [
           // XXX: hack for now.  Problem in taskcluster-vpn-proxy where resolv.conf
           // isn't updated when vpn'ed in so name resolution does not work.
-          "aus4-admin.mozilla.org:52.26.16.60"
+          "aus4-admin.mozilla.org:52.26.16.60",
           "balrog-admin.stage.mozaws.net:52.71.237.144"
         ]
       }

--- a/src/lib/features/balrog_vpn_proxy.js
+++ b/src/lib/features/balrog_vpn_proxy.js
@@ -78,6 +78,7 @@ export default class BalrogVPNProxy {
           // XXX: hack for now.  Problem in taskcluster-vpn-proxy where resolv.conf
           // isn't updated when vpn'ed in so name resolution does not work.
           "aus4-admin.mozilla.org:52.26.16.60"
+          "balrog-admin.stage.mozaws.net:52.71.237.144"
         ]
       }
     });


### PR DESCRIPTION
We're going to start using the Balrog stage environment more regularly for staging Releases. This looks like one of the things we'll need to make sure Funsize is able to submit to it.