### PR TITLE
Introduce `worker:cache:<name>` scope

### DIFF
--- a/src/lib/task.js
+++ b/src/lib/task.js
@@ -94,10 +94,13 @@ Create a list of cached volumes that will be mounted within the docker container
 @param {object} volumes to mount in the container
  */
 async function buildVolumeBindings(taskVolumeBindings, volumeCache, taskScopes) {
-  let allowed = await hasPrefixedScopes('docker-worker:cache:', taskVolumeBindings, taskScopes);
+  let allowed = (
+    (await hasPrefixedScopes('worker:cache:', taskVolumeBindings, taskScopes)) ||
+    (await hasPrefixedScopes('docker-worker:cache:', taskVolumeBindings, taskScopes))
+  );
   if (!allowed) {
     throw new Error('Insufficient scopes to attach cache volumes.  The task must ' +
-    'have scope `docker-worker:cache:<cache-name>` for each cache in `payload.caches`.');
+    'have scope `worker:cache:<cache-name>` for each cache in `payload.caches`.');
   }
 
   let bindings = [];


### PR DESCRIPTION
We could talk about doing the same for permissions and other stuff...

Note: this is more of a suggestion, we should probably not merge until we have some idea of how we want do this with other scopes... and maybe a plan for doing matching changes in-tree too..