### PR TITLE
Fix scopes unit test.

### DIFF
--- a/test/test_util_scopes.js
+++ b/test/test_util_scopes.js
@@ -11,8 +11,8 @@ suite('test lib/util/scopes', function() {
     ['starScope',   'pfx:', { vol1: '/vol1', vol2: '/vol2' }, ['pfx:*'], true],
     ['noResources', 'pfx:', {}, [], true],
   ].forEach((t)=> {
-    test(t[0], function() {
-        assert.equal(scopes.hasPrefixedScopes(t[1], t[2], t[3]), t[4]);
+    test(t[0], async function() {
+        assert.equal(await scopes.hasPrefixedScopes(t[1], t[2], t[3]), t[4]);
     });
   });
 });


### PR DESCRIPTION
scopes.hasPrefixedScopes is an async function and any call to it must
`await`. For reasons we probably we never know, the code used to pass
until we changed it in [1]. Now it returns a pending promise.

We fix this bad behavior by awaiting hasPrefixedScopes.

[1] https://github.com/taskcluster/docker-worker/pull/332