### PR TITLE
Correctly report the number of tasks we will try to claim.

### DIFF
--- a/src/lib/queueservice.js
+++ b/src/lib/queueservice.js
@@ -54,9 +54,11 @@ class TaskQueue {
    * @param {Array} claims
    */
   async claimWork(capacity) {
+    capacity = Math.min(capacity, MAX_MESSAGES_PER_REQUEST);
     debug(`polling for ${capacity} tasks`);
+
     let result = await this.queue.claimWork(this.provisionerId, this.workerType, {
-      tasks: Math.min(capacity, MAX_MESSAGES_PER_REQUEST),
+      tasks: capacity,
       workerGroup: this.workerGroup,
       workerId: this.workerId
     });


### PR DESCRIPTION
claimWork has a capacity parameter that it reports on debug log that's
the number of tasks it will try to claim, but that's not true, it
actually tries to claim min(capacity, MAX_MESSAGES_PER_REQUEST).