### PR TITLE
Fix volume mounting with overlay2 fs.

### DIFF
--- a/deploy/template/etc/default/docker-overlay2
+++ b/deploy/template/etc/default/docker-overlay2
@@ -8,7 +8,7 @@ if ! lvdisplay | grep instance_storage; then
   # c5 and newer has nvme* devices. The nvmeN devices can't be used
   # with vgcreate. But nvmeNnN can.
   if [ -e /dev/nvme0 ]; then
-    devices=$(ls /dev/nvme*n*)
+    devices=$(ls /dev/nvme*n* | grep -v '/dev/nvme0')
   else
     devices=$(ls /dev/xvd* | grep -v '/dev/xvda')
   fi


### PR DESCRIPTION
/dev/nvme0 must be excluded from LVM group, as we do in aufs.

@indygreg in my tests this seems to fix the docker daemon startup.