### PR TITLE
Tweak ext4 mount options for performance

### DIFF
--- a/deploy/template/etc/default/docker-overlay2
+++ b/deploy/template/etc/default/docker-overlay2
@@ -43,7 +43,32 @@ then
   else
     echo "Succesfully formated 'instance_storage' as ext4."
     echo "Mounting logical volume"
-    mount /dev/instance_storage/all /mnt
+
+    # Our assumption is that workers are ephemeral. If errors are encountered, the
+    # worker should be thrown away. Workers are never rebooted. So filesystem
+    # durability isn't too important to us.
+
+    # Default mount options: rw,relatime,errors=remount-ro,data=ordered
+    #
+    # We make the following changes:
+    #
+    # errors=panic -- The worker is unusable if the mount isn't writable. So
+    # panic if we encounter this.
+    #
+    # data=writeback -- Don't require write ordering between journal and main
+    # filesystem. Since we don't have a separate journal device, this probably
+    # does little. But in theory it relaxes durability so it shouldn't hurt.
+    #
+    # nobarrier -- Loosen restrictions around writes to journal.
+    #
+    # commit=60 -- By default, ext4 tries to sync every 5s to ensure
+    # minimal data loss in case of system failure. We increase that to 60s to
+    # avoid excessive filesystem sync. The filesystem will still write out
+    # changes in the background. And a `sync()` issued by an application can
+    # still force a full flush sooner. But ext4 itself won't be flushing all
+    # changes as often.
+
+    mount -o 'rw,relatime,errors=panic,data=writeback,nobarrier,commit=60' /dev/instance_storage/all /mnt
   fi
 else
   echo "Logical volume 'instance_storage' is already mounted."


### PR DESCRIPTION
Docker workers are ephemeral. They don't live longer than a single
boot.

The default configuration of Linux makes reasonable attempts to not
lose your data or corrupt your filesystem. It does this by ensuring
filesystem writes occur in a specific order and semi-frequently.

This commit relaxes the mount options of the ext4 volume used to back
Docker. We essentially disable protections around writing ordering
guarantees and lower the interval that ext4 performs background
flushing of pending writes.

With these changes, the filesystem will almost certainly be corrupted
if power loss or unclean shutdown occurs. However, the filesystem
is ephemeral - just like the instance is - so we shouldn't care.

The most contentious change in the lot is likely the change of the
"commit" value. We definitely want to increase this for performance.
However, I'm not sure if we should increase it to "infinity" or leave
it at something reasonable. The danger with increasing to "infinity"
is that a large amount of writes may pile up and when a sync() is
eventually performed or requested by an application, it could take
a very long time. I /think/ there are other flushing mechanisms and
high water marks in Linux that will kick in and mitigate this
scenario. But I didn't want to take the chance. So this change
only increases the commit interval from 5s to 60s. That's still
small, but is 12x longer than the previous value. So hopefully it
has some positive impact.