### PR TITLE
Add support for purging caches based on task exit status.

### DIFF
--- a/schemas/payload.json
+++ b/schemas/payload.json
@@ -219,7 +219,16 @@
             "title": "Exit statuses",
             "type": "number"
           }
-        }
+        },
+	"purgeCaches": {
+          "title": "Purge caches exit status",
+          "description": "If the task exists with a purge caches exit status, all caches associated with the task will be purged.",
+          "type": "array",
+          "items": {
+            "title": "Exit statuses",
+            "type": "number"
+          }
+	}
       }
     },
     "artifacts": {

--- a/src/lib/task.js
+++ b/src/lib/task.js
@@ -589,6 +589,12 @@ class Task extends EventEmitter {
         reporter = queue.reportFailed;
         taskState = 'failed';
       }
+      let purgeStatuses = this.task.payload.onExistStatus.purgeCaches;
+      if (purgeStatuses && purgeStatuses.includes(this.exitCode)) {
+        for (let cacheKey in this.task.volumeCaches) {
+          this.runtime.purgeInstance(cacheKey)
+        }
+      }
     }
 
     // mark any tasks that this one superseded as resolved, adding the

--- a/src/lib/volume_cache.js
+++ b/src/lib/volume_cache.js
@@ -218,6 +218,11 @@ class VolumeCache {
     this.log("cache volume release", {key: cacheKey});
   }
 
+  purgeInstance(cacheKey) {
+    this.set(cacheKey, {purge: true})
+    this.log("cache volume purge", {key: cacheKey});
+  }
+
   /**
   Set a property for a cached volume.
 

--- a/test/volume_cache_test.js
+++ b/test/volume_cache_test.js
@@ -239,4 +239,27 @@ suite('volume cache test', function () {
     instance2 = await cache.get(cacheName);
     assert.ok(instance1.key !== instance2.key);
   });
+
+  test('purge volume cache instance', async () => {
+    // After purging an instance of a cache, future requests for that cache
+    // return new instances.
+    var cache = new VolumeCache({
+      cache: {
+        volumeCachePath: localCacheDir
+      },
+      log: debug,
+      monitor: monitor
+    });
+
+    var cacheName = 'tmp-obj-dir-' + Date.now().toString();
+    var fullPath = path.join(localCacheDir, cacheName);
+
+    var purgedInstance = await cache.get(cacheName);
+
+    await cache.purgeInstance(purgedInstance.key);
+    await cache.release(purgedInstance.key);
+
+    var freshInstance = await cache.get(cacheName);
+    assert.notEqual(freshInstance.key !== purgedInstance.key);
+  });
 });


### PR DESCRIPTION
This should allow failures like https://bugzilla.mozilla.org/show_bug.cgi?id=1297151 and https://bugzilla.mozilla.org/show_bug.cgi?id=1426445 gracefully.