### PR TITLE
Use correct error string.

### DIFF
--- a/src/lib/states.js
+++ b/src/lib/states.js
@@ -50,12 +50,12 @@ class States {
           return hook[method](task)
             .then(info => { return info; })
             .catch(err => {
-              errors.push(new Error(`Error calling '${method}' for ${hook.featureName} : ${err.message}`));
+              errors.push(new Error(`Error calling '${method}' for ${hook.featureName} : ${err}`));
             });
         })
     ).then(results => {
       if (errors.length > 0) {
-        throw new Error(errors.map(e => e.message).join(' | '));
+        throw new Error(errors.map(e => e).join(' | '));
       }
       return results;
     });


### PR DESCRIPTION
In Bug 1387365 we see a strange behavior where an error is thrown but
the Error object is underfined. Instead of err.message, we use the Error
object as the string format, so if it is undefined, we still have some
information about the original error.