### PR TITLE
Provide a script to create github releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,10 +280,21 @@ folders.
     Given the backup file, this scripts rolls back the worker type configuration.
     It requires node 8.5.0+.
 
+  - [deploy/bin/github-release.js](/deploy/bin/github-release.js) :
+    It creates a Github release of the current branch. Do not use this script
+    directly, use the [release.sh](/release.sh) script, which does some safe
+    checks before releasing.
+
 If eveything is alright, all should you do to deploy docker-worker is to run
-[release.sh](/release.sh). You need the
+[deploy.sh](/deploy.sh). You need the
 [secrets](ssh://gitolite3@git-internal.mozilla.org/taskcluster/secrets.git)
 repo configured.
+
+After running [deploy.sh](/deploy.sh), you can make a Github release of the
+deployed AMIs by running [release.sh](/release.sh). It creates the Github
+release and uploads the `docker-worker-amis.json` and
+`worker-types-backup.json` files. You need to setup a Github personal access
+token and put it in a environment variable called `DOCKER_WORKER_GITHUB_TOKEN`.
 
 ### Block-Device Mapping
 The AMI built with packer will mount all available instances storage under

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,29 @@
+#!/bin/bash -e
+
+deploy_json=deploy/deploy.json;
+
+NODE_VERSION_MAJOR=$(node --version | tr -d v | awk -F. '{print $1}')
+NODE_VERSION_MINOR=$(node --version | tr -d v | awk -F. '{print $2}')
+
+if [ "$TASKCLUSTER_CLIENT_ID" == "" -o "$TASKCLUSTER_ACCESS_TOKEN" == "" ]; then
+    echo "You don't seem to have proper Taskcluster credentials, please run 'taskcluster-cli signin' command" >&2
+    exit 1
+fi
+
+if [ 0$NODE_VERSION_MAJOR -lt 8 -o 0$NODE_VERSION_MINOR -lt 5 ]; then
+  echo "$0 requires node version 8.5.0 or higher." >&2
+  exit 1
+fi
+
+if ! [ -d $HOME/.password-store ]; then
+    echo "Password store not found, please install it by running:"
+    echo "git clone ssh://gitolite3@git-internal.mozilla.org/taskcluster/secrets.git $HOME/.password-store"
+    echo "To clone this repository, you need Mozilla VPN access. Please check \
+https://mana.mozilla.org/wiki/display/IT/Mozilla+VPN for information on how to setup VPN connection."
+    exit 1
+fi
+
+deploy/bin/import-docker-worker-secrets
+deploy/bin/build app
+deploy/bin/update-worker-types.js $*
+rm -f /tmp/docker-worker*

--- a/deploy/bin/github-release.js
+++ b/deploy/bin/github-release.js
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+const GithubApi = require('github');
+const fs = require('fs');
+const mime = require('mime');
+const path = require('path');
+const dateformat = require('dateformat');
+
+const RELEASE_NAME = dateformat(new Date(), 'vyyyymmddHHMM');
+const OWNER = 'taskcluster';
+const REPO = 'docker-worker';
+
+function signin() {
+  if (!process.env.DOCKER_WORKER_GITHUB_TOKEN) {
+    throw new Error(
+      'You supply a user token thorugh the environment variable DOCKER_WORKER_GITHUB_TOKEN'
+    );
+  }
+
+  const github = new GithubApi({
+    timeout: 5000,
+    host: 'api.github.com',
+    protocol: 'https',
+    headers: {
+      'user-agent': 'docker-worker'
+    },
+    rejectUnauthorized: false, // default: true
+  });
+
+  github.authenticate({
+    type: 'token',
+    token: process.env.DOCKER_WORKER_GITHUB_TOKEN,
+  });
+
+  return github;
+}
+
+function createRelease(github) {
+  return github.repos.createRelease({
+    owner: 'taskcluster',
+    repo: 'docker-worker',
+    tag_name: RELEASE_NAME,
+    name: RELEASE_NAME,
+  })
+}
+
+// upload a file as a release asset
+function uploadFile(github, filename) {
+  const stat = fs.statSync(filename);
+  const stream = fs.createReadStream(filename);
+
+  return github.repos.getReleaseByTag({
+    owner: OWNER,
+    repo: REPO,
+    tag: RELEASE_NAME,
+  }).then(result => {
+    return github.repos.uploadAsset({
+      url: result.data.upload_url,
+      file: stream,
+      contentType: mime.lookup(filename),
+      contentLength: stat.size,
+      name: path.basename(filename),
+    });
+  });
+}
+
+function main() {
+  const github = signin();
+  createRelease(github)
+    .then(() => uploadFile(github, 'worker-types-backup.json'))
+    .then(() => uploadFile(github, 'docker-worker-amis.json'))
+    .then(() => console.log(RELEASE_NAME))
+    .catch(err => {
+      console.error(err.stack || err);
+
+      // If something goes wrong we delete the release
+      github.repos.getReleaseByTag({
+        owner: OWNER,
+        repo: REPO,
+        tag: RELEASE_NAME,
+      }).then(result => {
+        github.repos.deleteRelease({
+          owner: OWNER,
+          repo: REPO,
+          id: result.data.id,
+        });
+      });
+
+      process.exit(1);
+    });
+}
+
+process.on('unhandledRejection', (err, p) => {
+  console.error(err.stack || err);
+  process.exit(1);
+});
+
+main();

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "co": "^4.6.0",
     "co-prompt": "^1.0.0",
     "commander": "^2.2.0",
+    "dateformat": "^3.0.2",
     "debug": "*",
     "dev-null": "^0.1.0",
     "diskspace": "^1.0.3",
@@ -74,5 +75,8 @@
     "uuid": "^2.0.0",
     "websocket-stream": "^3.3.0",
     "ws": "^1.1.1"
+  },
+  "devDependencies": {
+    "github": "^13.1.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -27,6 +27,12 @@ accepts@~1.1.0:
     mime-types "~2.0.4"
     negotiator "0.4.9"
 
+agent-base@^4.1.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-4.2.0.tgz#9838b5c3392b962bad031e6a4c5e1024abec45ce"
+  dependencies:
+    es6-promisify "^5.0.0"
+
 ajv@^3.8.5:
   version "3.8.10"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-3.8.10.tgz#78dfd5615e2cf4c0f8cb7f3284e0257dbbe867c9"
@@ -594,6 +600,10 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
+dateformat@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-3.0.2.tgz#9a4df4bff158ac2f34bc637abdb15471607e1659"
+
 debug@*, debug@2, debug@2.6.1, debug@^2.0.0, debug@^2.1.0, debug@^2.1.3, debug@^2.2.0, debug@^2.6.0:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.1.tgz#79855090ba2c4e3115cc7d8769491d58f0491351"
@@ -615,6 +625,12 @@ debug@2.2.0, debug@~2.2.0:
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.2.0.tgz#f87057e995b1a1f6ae6a4960664137bc56f039da"
   dependencies:
     ms "0.7.1"
+
+debug@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
+  dependencies:
+    ms "2.0.0"
 
 debug@~0.7.2, debug@~0.7.4:
   version "0.7.4"
@@ -769,6 +785,10 @@ dockerode@^2.3.0:
     docker-modem "0.3.x"
     tar-fs "~1.12.0"
 
+dotenv@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-4.0.0.tgz#864ef1379aced55ce6f95debecdce179f7a0cd1d"
+
 duplexer2@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/duplexer2/-/duplexer2-0.1.4.tgz#8b12dab878c0d69e3e7891051662a32fc6bddcc1"
@@ -867,6 +887,16 @@ es6-iterator@2:
     d "^0.1.1"
     es5-ext "^0.10.7"
     es6-symbol "3"
+
+es6-promise@^4.0.3:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.2.tgz#f722d7769af88bd33bc13ec6605e1f92966b82d9"
+
+es6-promisify@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/es6-promisify/-/es6-promisify-5.0.0.tgz#5109d62f3e56ea967c4b63505aef08291c8a5203"
+  dependencies:
+    es6-promise "^4.0.3"
 
 es6-symbol@3, es6-symbol@~3.1:
   version "3.1.0"
@@ -1185,6 +1215,18 @@ getpass@^0.1.1:
   dependencies:
     assert-plus "^1.0.0"
 
+github@^13.1.0:
+  version "13.1.0"
+  resolved "https://registry.yarnpkg.com/github/-/github-13.1.0.tgz#fc925950beebdff0cb0583197598b86f41bedaa4"
+  dependencies:
+    debug "^3.1.0"
+    dotenv "^4.0.0"
+    https-proxy-agent "^2.1.0"
+    is-stream "^1.1.0"
+    lodash "^4.17.4"
+    proxy-from-env "^1.0.0"
+    url-template "^2.0.8"
+
 glob@7.0.5:
   version "7.0.5"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.0.5.tgz#b4202a69099bbb4d292a7c1b95b6682b67ebdc95"
@@ -1370,6 +1412,13 @@ http-signature@~1.1.0:
     jsprim "^1.2.2"
     sshpk "^1.7.0"
 
+https-proxy-agent@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-2.1.1.tgz#a7ce4382a1ba8266ee848578778122d491260fd9"
+  dependencies:
+    agent-base "^4.1.0"
+    debug "^3.1.0"
+
 iconv-lite@0.4.11:
   version "0.4.11"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.11.tgz#2ecb42fd294744922209a2e7c404dac8793d8ade"
@@ -1449,7 +1498,7 @@ is-retry-allowed@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz#11a060568b67339444033d0125a61a20d564fb34"
 
-is-stream@^1.0.0, is-stream@^1.0.1:
+is-stream@^1.0.0, is-stream@^1.0.1, is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
 
@@ -1859,6 +1908,10 @@ ms@0.7.2, ms@^0.7.1:
   version "0.7.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.2.tgz#ae25cf2512b3885a1d95d7f037868d8431124765"
 
+ms@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
+
 mz@^2.0.0, mz@^2.4.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/mz/-/mz-2.6.0.tgz#c8b8521d958df0a4f2768025db69c719ee4ef1ce"
@@ -2174,6 +2227,10 @@ proxy-addr@~1.1.3:
   dependencies:
     forwarded "~0.1.0"
     ipaddr.js "1.2.0"
+
+proxy-from-env@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.0.0.tgz#33c50398f70ea7eb96d21f7b817630a55791c7ee"
 
 pruddy-error@1.0.x:
   version "1.0.2"
@@ -3335,6 +3392,10 @@ url-parse@^1.1.1:
   dependencies:
     querystringify "0.0.x"
     requires-port "1.0.x"
+
+url-template@^2.0.8:
+  version "2.0.8"
+  resolved "https://registry.yarnpkg.com/url-template/-/url-template-2.0.8.tgz#fc565a3cccbff7730c775f5641f9555791439f21"
 
 url@0.10.3:
   version "0.10.3"


### PR DESCRIPTION
The old release.sh script is now called deploy.sh. The new release.sh is
intended to create a Github release of docker-worker.

By running it, it creates a tag which name is based on current date
and time, and uploads the worker-types-backup.json and
docker-worker-amis.jsonjson files.

release.sh is intended to run right after deploy.sh. The reason to put
them in two scripts is because we may want to test the new rolled out
AMIs first before doing a release, or we are just rolling out AMIs on
testing worker-types during development.

Notice the release script requires an environment variable called
DOCKER_WORKER_GITHUB_TOKEN with a user personal token set.