### PR TITLE
Knockout paravirtual AMIs

### DIFF
--- a/deploy/etc/worker-types-test.json
+++ b/deploy/etc/worker-types-test.json
@@ -3,8 +3,5 @@
     "ami-test"
   ],
   "hvm-builder-trusted": [
-  ],
-  "pv-builder": [
-    "ami-test-pv"
   ]
 }

--- a/deploy/etc/worker-types.json
+++ b/deploy/etc/worker-types.json
@@ -62,8 +62,5 @@
     "gecko-3-images",
     "gecko-images",
     "taskcluster-images"
-  ],
-  "pv-builder": [
-    "gecko-t-linux-medium"
   ]
 }

--- a/deploy/packer/app.json
+++ b/deploy/packer/app.json
@@ -5,7 +5,6 @@
     "npmPackage":          "",
     "templateContents":    "",
     "hvmSourceAMI":        "ami-a418bddc",
-    "pvSourceAMI":         "ami-c01bbeb8",
     "fsType":              "",
     "workerRevision":      ""
   },
@@ -37,7 +36,7 @@
     {
       "type":           "shell",
       "inline":         ["/tmp/gen-signing-key"],
-      "only":           ["hvm-builder", "pv-builder"]
+      "only":           ["hvm-builder"]
     },
     {
       "type":           "file",
@@ -95,22 +94,6 @@
         "Release":          "Latest",
         "Revision":         "{{user `workerRevision`}}",
         "Base_AMI":         "{{user `hvmSourceAMI`}}"
-      }
-    },
-    {
-      "type":           "amazon-ebs",
-      "name":           "pv-builder",
-      "region":         "us-west-2",
-      "ami_regions":    ["us-west-1", "us-east-1"],
-      "source_ami":     "{{user `pvSourceAMI`}}",
-      "instance_type":  "m1.medium",
-      "ssh_username":   "ubuntu",
-      "ami_name":       "taskcluster-docker-worker-{{user `fsType`}}-PV-{{timestamp}}",
-      "tags": {
-        "OS_Version":       "Ubuntu",
-        "Release":          "Latest",
-        "Revision":         "{{user `workerRevision`}}",
-        "Base_AMI":         "{{user `pvSourceAMI`}}"
       }
     }
   ],

--- a/deploy/packer/base.json
+++ b/deploy/packer/base.json
@@ -66,21 +66,6 @@
         "Release":    "Latest",
         "Revision":   "{{user `workerRevision`}}"
       }
-    },
-    {
-      "type": "amazon-ebs",
-      "name": "pv-builder",
-      "region": "us-west-2",
-      "source_ami": "ami-0fcf1c77",
-      "ami_virtualization_type": "paravirtual",
-      "instance_type": "m1.medium",
-      "ssh_username": "ubuntu",
-      "ami_name": "taskcluster-docker-worker-base PV {{timestamp}}",
-      "tags": {
-        "OS_Version": "Ubuntu",
-        "Release":    "Latest",
-        "Revision":   "{{user `workerRevision`}}"
-      }
     }
   ]
 }


### PR DESCRIPTION
paravirtual AMIs are only used by the gecko-t-linux-medium worker type,
which receives no job.