### PR TITLE
Bug 1431950 - check for onExitStatus before purgeCaches check

### DIFF
--- a/src/lib/task.js
+++ b/src/lib/task.js
@@ -589,7 +589,7 @@ class Task extends EventEmitter {
         reporter = queue.reportFailed;
         taskState = 'failed';
       }
-      let purgeStatuses = this.task.payload.onExistStatus.purgeCaches;
+      let purgeStatuses = this.task.payload.onExitStatus && this.task.payload.onExitStatus.purgeCaches;
       if (purgeStatuses && purgeStatuses.includes(this.exitCode)) {
         for (let cacheKey in this.task.volumeCaches) {
           this.runtime.purgeInstance(cacheKey)


### PR DESCRIPTION
I believe this should fix the current issues with failing to report failed tasks.