### PR TITLE
Add the current user to docker group

### DIFF
--- a/deploy/packer/base/scripts/packages.sh
+++ b/deploy/packer/base/scripts/packages.sh
@@ -10,7 +10,7 @@ lsb_release -a
 
 # add docker group and add current user to it
 sudo groupadd -f docker
-sudo usermod -a -G docker $USER
+sudo usermod -a -G docker $SUDO_USER
 
 sudo apt-get update -y
 


### PR DESCRIPTION
In the context of sudo, $USER is the root user, but we want to add the
calling user to docker group, which is $SUDO_USER.