### PR TITLE
Fix AWS config test

### DIFF
--- a/test/aws_host_config_test.js
+++ b/test/aws_host_config_test.js
@@ -50,6 +50,7 @@ suite('configuration/aws', () => {
     assert.deepEqual(config, {
       host: 'publichost',
       shutdown: {
+        afterIdleSeconds: 900,
         enabled: true,
       },
       provisionerId: 'aws-provisioner',


### PR DESCRIPTION
PR #352 added a new configuration field, which, as a side effect, broke
AWS config test.