### PR TITLE
Fix docker group for base AMI

### DIFF
--- a/deploy/packer/base/scripts/packages.sh
+++ b/deploy/packer/base/scripts/packages.sh
@@ -10,7 +10,17 @@ lsb_release -a
 
 # add docker group and add current user to it
 sudo groupadd -f docker
-sudo usermod -a -G docker $SUDO_USER
+
+# Make sure we use add the calling user to docker
+# group. If the the script itself is called with sudo,
+# we must use SUDO_USER, otherwise, use USER.
+if [ -z "${VAGRANT_PROVISION}" ]; then
+    user=$USER
+else
+    user=$SUDO_USER
+fi
+
+sudo usermod -a -G docker $user
 
 sudo apt-get update -y
 


### PR DESCRIPTION
PR #366 fixed docker group addition for Vagrant but broke the script for
AMI generation. This commit fixes it for both cases.

When building the AMI, we get the current user from $USER environment
variable. For Vagrant provisioning, we use $SUDO_USER.