### PR TITLE
Fix call to temporary.unlink

### DIFF
--- a/src/lib/upload_to_s3.js
+++ b/src/lib/upload_to_s3.js
@@ -126,7 +126,7 @@ module.exports = async function uploadToS3 (
     // randomize the timeouts
     }, {randomize: true});
   } finally {
-    tmp.unlink();
+    tmp.unlinkSync();
   }
 
   return {digest, size};


### PR DESCRIPTION
temporary.unlink is an asynchronous function that requires a callback.
Let's use the sync version of it to make node happy.