### PR TITLE
Fix directory upload retry test case

### DIFF
--- a/test/integration/directory_artifact_test.js
+++ b/test/integration/directory_artifact_test.js
@@ -95,11 +95,6 @@ suite('Directory artifact', function() {
   });
 
   test('retry directory upload', async () => {
-    // Avoid iptables on local environment
-    if (!process.env.WORKER_CI) {
-      return;
-    }
-
     this.timeout(480000);
 
     let ARTIFACT_COUNT = 3;
@@ -110,16 +105,12 @@ suite('Directory artifact', function() {
     var count = 0;
 
     let rejectConnection = function() {
-      // Delay iptables rejection to catch
-      // in the middle of the upload
-      setTimeout(function() {
-        iptables.reject({
-          chain: 'OUTPUT',
-          protocol: 'tcp',
-          dport: 443,
-          sudo: true
-        });
-      }, 100);
+      iptables.reject({
+        chain: 'OUTPUT',
+        protocol: 'tcp',
+        dport: 443,
+        sudo: true
+      });
     }
 
     let cmdArgs = ['mkdir "/xfoo"'];


### PR DESCRIPTION
The directory retry upload test case tests if a directory upload will
retry successfully. Because we put a small delay in the code that blocks
the upload, instead of blocking the artifact upload, we failed the
createArtifact call of the next artifact, causing the whole test
case failure.

We now do the same way we do for file upload retry test: once we receive
the event that the upload is starting, we block the related TCP port to
simulate a network issue.

We also remove the code that disabled the test in non CI environments.
The reasoning originaly behind this was to avoid messing up with iptables
in the development environment, but since tests run under a virtual
machine, we don't need to worry about it.