### PR TITLE
Dump docker-worker debug tests on CI tests

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -110,6 +110,7 @@ tasks:
           loopbackVideo: true
       env:
         WORKER_CI: '1'
+        DEBUG: '*docker-worker*'
       features:
         taskclusterProxy: true
     metadata:
@@ -151,6 +152,7 @@ tasks:
           loopbackVideo: true
       env:
         WORKER_CI: '1'
+        DEBUG: '*docker-worker*'
       features:
         taskclusterProxy: true
     metadata:
@@ -192,6 +194,7 @@ tasks:
           loopbackVideo: true
       env:
         WORKER_CI: '1'
+        DEBUG: '*docker-worker*'
       features:
         taskclusterProxy: true
     metadata:
@@ -233,6 +236,7 @@ tasks:
           loopbackVideo: true
       env:
         WORKER_CI: '1'
+        DEBUG: '*docker-worker*'
       features:
         taskclusterProxy: true
     metadata:
@@ -274,6 +278,7 @@ tasks:
           loopbackVideo: true
       env:
         WORKER_CI: '1'
+        DEBUG: '*docker-worker*'
       features:
         taskclusterProxy: true
     metadata:


### PR DESCRIPTION
There are still tests that fail once in a while and it is hard to make
they fail again in development environment. Let's add thr docker-worker
debug message to CI, so when a test fails for no reason, we can debug
why.