### PR TITLE
Bug 1427938: Mitigate Meltdown/Spectre

### DIFF
--- a/deploy/packer/app.json
+++ b/deploy/packer/app.json
@@ -4,7 +4,7 @@
   "variables": {
     "npmPackage":          "",
     "templateContents":    "",
-    "hvmSourceAMI":        "ami-a418bddc",
+    "hvmSourceAMI":        "ami-d634b9ae",
     "workerRevision":      ""
   },
   "provisioners": [


### PR DESCRIPTION
Canonical isn't going to patch kernel 4.4.0 on trusty for
Meltdown/Spectre bugs. This forces us to switch to linux-aws kernel, but
this kernel doesn't include the V4L2 and snd-aloop modules, necessary to
run tests Firefox on docker containers.

We now have our own custom kernel [1] and PPA [2]. This kernel is based
on the linux-aws, but with V4L2 and snd-aloop enabled.

[1] https://github.com/taskcluster/linux-aws-trusty
[2] https://launchpad.net/~taskcluster/+archive/ubuntu/ppa