### PR TITLE
Generate apparmor profile in memory

### DIFF
--- a/src/lib/task.js
+++ b/src/lib/task.js
@@ -25,6 +25,47 @@ const uploadToS3 = require('./upload_to_s3');
 const _ = require('lodash');
 const EventEmitter = require('events');
 
+const APP_ARMOR_TEMPLATE = `
+#include <tunables/global>
+
+
+profile docker-default flags=(attach_disconnected,mediate_deleted) {
+
+  #include <abstractions/base>
+
+
+  network,
+  capability,
+  file,
+  umount,
+
+  deny @{PROC}/* w,   # deny write for all files directly in /proc (not in a subdir)
+  # deny write to files not in /proc/<number>/** or /proc/sys/**
+  deny @{PROC}/{[^1-9],[^1-9][^0-9],[^1-9s][^0-9y][^0-9s],[^1-9][^0-9][^0-9][^0-9]*}/** w,
+  deny @{PROC}/sys/[^k]** w,  # deny /proc/sys except /proc/sys/k* (effectively /proc/sys/kernel)
+  deny @{PROC}/sys/kernel/{?,??,[^s][^h][^m]**} w,  # deny everything except shm* in /proc/sys/kernel/
+  deny @{PROC}/sysrq-trigger rwklx,
+  deny @{PROC}/mem rwklx,
+  deny @{PROC}/kmem rwklx,
+  deny @{PROC}/kcore rwklx,
+
+  deny mount,
+
+  deny /sys/[^f]*/** wklx,
+  deny /sys/f[^s]*/** wklx,
+  deny /sys/fs/[^c]*/** wklx,
+  deny /sys/fs/c[^g]*/** wklx,
+  deny /sys/fs/cg[^r]*/** wklx,
+  deny /sys/firmware/efi/efivars/** rwklx,
+  deny /sys/kernel/security/** rwklx,
+
+
+  # suppress ptrace denials when using 'docker ps' or using 'ps' inside a container
+  ptrace (trace,read) peer=docker-default,
+
+}
+`;
+
 let debug = new Debug('runTask');
 
 const PAYLOAD_SCHEMA =
@@ -419,13 +460,9 @@ class Task extends EventEmitter {
   }
 
   async makePtraceAppArmorProfile() {
-    // copy and modify the docker-default profile
-    let profile = await fs.readFile('/etc/apparmor.d/docker');
     let name = 'worker-' + this.status.taskId + '-' + this.runId;
 
-    // update the name of the profile
-    profile = profile.toString('utf-8');
-    profile = profile.replace('profile docker-default', 'profile ' + name);
+    let profile = APP_ARMOR_TEMPLATE.replace('profile docker-default', 'profile ' + name);
 
     // add a rule allowing ptrace to other processes with this policy, at
     // the very end


### PR DESCRIPTION
As we upgraded docker, the default profile isn't stored in
/etc/apparmor.d/docker anymore. We now store the apparmor template for
docker as a constant variable, making agnostic regarding the docker
version.