### PR TITLE
Use UTC date for github release name

### DIFF
--- a/deploy/bin/github-release.js
+++ b/deploy/bin/github-release.js
@@ -5,7 +5,7 @@ const mime = require('mime');
 const path = require('path');
 const dateformat = require('dateformat');
 
-const RELEASE_NAME = dateformat(new Date(), 'vyyyymmddHHMM');
+const RELEASE_NAME = dateformat(new Date(), 'vyyyymmddHHMM', true);
 const OWNER = 'taskcluster';
 const REPO = 'docker-worker';
 


### PR DESCRIPTION
I spotted the github release names (e.g. `v201803060918`) were based on date and time in São Paulo... 😜 

The change in this PR is to use a release name which relates to the (neutral) UTC timezone. I referred to the [dateformat usage docs](https://www.npmjs.com/package/dateformat#usage) to guess how to fix this:

> ```js
> // And finally, you can convert local time to UTC time. Simply pass in
> // true as an additional argument (no argument skipping allowed in this case):
> dateFormat(now, "longTime", true);
> // 10:46:21 PM UTC
> 
> // ...Or add the prefix "UTC:" or "GMT:" to your mask.
> dateFormat(now, "UTC:h:MM:ss TT Z");
> // 10:46:21 PM UTC
> ```

Please note, this is untested, as I didn't really want to make a release... 😝 