### PR TITLE
bug 1452266 - indent chainOfTrust.json

### DIFF
--- a/src/lib/features/chain_of_trust.js
+++ b/src/lib/features/chain_of_trust.js
@@ -95,7 +95,7 @@ class ChainOfTrust {
     });
 
     let signedChainOfTrust = await openpgp.sign({
-      data: JSON.stringify(certificate),
+      data: JSON.stringify(certificate, null, 2),
       privateKeys: this.key
     });
 


### PR DESCRIPTION
gpg signature verification has a max line length of 20k chars. By using newlines and indents, we avoid hitting this limit.