### PR TITLE
Remove --harmony flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ are for hacking on the worker itself.
 
 ```
 # from the root of this repo) also see --help
-node --harmony bin/worker.js <config>
+node bin/worker.js <config>
 ```
 
 ### Configuration
@@ -337,7 +337,7 @@ into your environment. See
 
 Run the upload-schema.js script to update the schema:
 
-`babel-node --harmony bin/upload-schema.js`
+`babel-node bin/upload-schema.js`
 
 ### Post-Deployment Verification
 


### PR DESCRIPTION
Since issues are closed on this repository, I'm filing this as a PR instead.

The `--harmony` flag should never be used in production deployments; it's meant to enable unstable and broken features for experimental testing purposes. It's therefore a bad idea to recommend people to use it for their application.

If newer features are needed than the current version of the Node.js runtime supports, then either the runtime should be upgraded, or something like [Babel](https://babeljs.io) should be used (optionally with polyfills) to transpile the code to a stable implementation in an older ECMAScript version.

(I've just had to instruct somebody to remove the `--harmony` flag from their deployment; they had no idea what it did or what the consequences are, but figured it was necessary because it was documented here.)