### PR TITLE
Bug 1438218: cancel reclaims when we receive a node termination event

### DIFF
--- a/src/lib/task.js
+++ b/src/lib/task.js
@@ -800,6 +800,7 @@ class Task extends EventEmitter {
    * @param {String} reason - Reason for aborting the test run (Example: worker-shutdown)
   */
   abort(reason) {
+    this.stopReclaims();
     this.taskState = 'aborted';
     this.taskException = reason;
     if (this.dockerProcess) this.dockerProcess.kill();


### PR DESCRIPTION
There are a few cases in which the worker receives a shutdown request
but after that it tries to reclaim a running task.