### PR TITLE
Bug 1458737: Reboot the instance on OOM

### DIFF
--- a/deploy/packer/app/scripts/deploy.sh
+++ b/deploy/packer/app/scripts/deploy.sh
@@ -46,6 +46,11 @@ docker pull taskcluster/livelog:v4
 docker pull taskcluster/dind-service:v4.0
 docker pull taskcluster/relengapi-proxy:2.0.1
 
+# Reboot the machine on OOM
+# Ref: http://www.oracle.com/technetwork/articles/servers-storage-dev/oom-killer-1911807.html
+echo "vm.panic_on_oom=1" >> /etc/sysctl.conf
+echo "kernel.panic=1" >> /etc/sysctl.conf
+
 # Export the images as a tarball to load when insances are initialized
 docker save taskcluster/taskcluster-proxy:4.0.1 taskcluster/livelog:v4 taskcluster/dind-service:v4.0 taskcluster/relengapi-proxy:2.0.1 > /home/ubuntu/docker_worker/docker_worker_images.tar
 


### PR DESCRIPTION
When OOM Killer is triggered, it can kill any process in the system. The
safest measure it to reboot the instance.