### PR TITLE
expire logs when the task expires

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -87,11 +87,6 @@ defaults:
     secureLiveLogging: false
     # Used by Azure live logger to chunk writes and send on an interval
     liveLogChunkInterval: 5000 # 5 seconds
-    # Added to the current date to make up the expiry time for logs. This is
-    # hack to generate a year in ms... Note that two args (year, month) are
-    # required here instead of one due to some quirk of v8...
-    liveLogExpires: '1 year'
-    bulkLogExpires: '1 year'
 
   task:
     # We must reclaim somewhat frequently (but not too frequently) this is the
@@ -202,11 +197,6 @@ test:
   ssl:
     certificate: '/worker/test/fixtures/ssl_cert.crt'
     key: '/worker/test/fixtures/ssl_cert.key'
-
-  logging:
-    # Expires one hour from now so test logs don't live too long...
-    liveLogExpires: '1 hour'
-    bulkLogExpires: '1 hour'
 
   cache:
     volumeCachePath: '/tmp/test-cache'

--- a/src/lib/features/bulk_log.js
+++ b/src/lib/features/bulk_log.js
@@ -46,8 +46,9 @@ class BulkLog {
     // Open a new stream to read the entire log from disk (this in theory could
     // be a huge file).
     let diskStream = fs.createReadStream(this.file.path);
-    let expiration = taskcluster.fromNow(task.runtime.logging.bulkLogExpires);
-    expiration = new Date(Math.min(expiration, new Date(task.task.expires)));
+
+    // expire the log when the task expires
+    let expiration = new Date(task.task.expires);
 
     try {
       await uploadToS3(task.queue, task.status.taskId, task.runId,

--- a/src/lib/features/local_live_log.js
+++ b/src/lib/features/local_live_log.js
@@ -144,9 +144,8 @@ class TaskclusterLogs {
 
     let queue = task.queue;
 
-    // Intentionally used the same expiration as the bulkLog
-    let expiration = taskcluster.fromNow(task.runtime.logging.bulkLogExpires);
-    expiration = new Date(Math.min(expiration, new Date(task.task.expires)));
+    // expire the log when the task expires (it will be a redirect by then)
+    let expiration = new Date(task.task.expires);
 
     // Create the redirect artifact...
     await queue.createArtifact(
@@ -192,8 +191,7 @@ class TaskclusterLogs {
 
     // Switch references to the new log file on s3 rather then the local worker
     // server...
-    let expiration = taskcluster.fromNow(task.runtime.logging.bulkLogExpires);
-    expiration = new Date(Math.min(expiration, new Date(task.task.expires)));
+    let expiration = new Date(task.task.expires);
 
     await task.queue.createArtifact(
       task.status.taskId,

--- a/test/integration/logging/secure_local_live_logging_test.js
+++ b/test/integration/logging/secure_local_live_logging_test.js
@@ -37,8 +37,6 @@ suite('secure local live logging', () => {
     settings.configure({
       logging: {
         secureLiveLogging: true,
-        liveLogExpires: '1 hour',
-        bulkLogExpires: '1 hour'
       }
     });
 
@@ -121,8 +119,6 @@ suite('secure local live logging', () => {
     settings.configure({
       logging: {
         secureLiveLogging: true,
-        liveLogExpires: 3600,
-        bulkLogExpires: 3600
       },
       shutdown: {
         enabled: true,


### PR DESCRIPTION
There's a test for taskcluster-cli (TestLogCommand) that looks at task TtAsnXdCS1-tAQxvMO4rHQ which was supposed to last for 1000 years.  Unfortunately, its logs only lasted a year.  And apparently, that's the longest docker-worker is willing to allow a task's logs to last.

This PR removes that, and just sets the log expires to be the same as the task expires.

Was there some reason for this max?