### PR TITLE
Bug 1472913: Increase dind-service wait timeout

### DIFF
--- a/src/lib/features/dind.js
+++ b/src/lib/features/dind.js
@@ -13,7 +13,7 @@ const {makeDir, removeDir} = require('../util/fs');
 let debug = require('debug')('docker-worker:features:dind');
 
 // Maximum time to wait for dind-service to be ready
-const INIT_TIMEOUT = 30 * 1000;
+const INIT_TIMEOUT = 60 * 1000;
 
 class DockerInDocker {
   constructor() {


### PR DESCRIPTION
The dind-service may wait for up to 60 seconds for the dind socket be
ready [1]. Lets use the same timeout here.

[1] https://github.com/taskcluster/dind-service/blob/master/entrypoint.sh#L97