### PR TITLE
Bug 1490964 - tighten docker-worker payload schema

### DIFF
--- a/schemas/payload.json
+++ b/schemas/payload.json
@@ -3,6 +3,7 @@
   "definitions": {
     "artifact": {
       "type": "object",
+      "additionalProperties": false,
       "properties": {
         "type": {
           "title": "Artifact upload type.",
@@ -35,16 +36,20 @@
     "image",
     "maxRunTime"
   ],
+  "additionalProperties": false,
   "properties": {
     "image": {
       "title": "Docker image.",
       "description": "Image to use for the task.  Images can be specified as an image tag as used by a docker registry, or as an object declaring type and name/namespace",
       "oneOf": [
         {
+          "title": "Docker image name",
           "type": "string"
         },
         {
           "type": "object",
+          "title": "Named docker image",
+          "additionalProperties": false,
           "properties": {
             "type": {
               "type": "string",
@@ -63,6 +68,8 @@
         },
         {
           "type": "object",
+          "title": "Indexed docker image",
+          "additionalProperties": false,
           "properties": {
             "type": {
               "type": "string",
@@ -85,6 +92,8 @@
         },
         {
           "type": "object",
+          "title": "Docker image artifact",
+          "additionalProperties": false,
           "properties": {
             "type": {
               "type": "string",
@@ -110,12 +119,16 @@
     "cache": {
       "title": "Caches to mount point mapping.",
       "description": "Caches are mounted within the docker container at the mount point specified. Example: ```{ \"CACHE NAME\": \"/mount/path/in/container\" }```",
+      "additionalProperties": {
+        "type": "string"
+      },
       "type": "object"
     },
     "capabilities": {
       "title": "Capabilities that must be available/enabled for the task container.",
       "description": "Set of capabilities that must be enabled or made available to the task container Example: ```{ \"capabilities\": { \"privileged\": true }```",
       "type": "object",
+      "additionalProperties": false,
       "properties": {
         "privileged": {
           "title": "Privileged container",
@@ -127,6 +140,7 @@
           "title": "Devices to be attached to task containers",
           "description": "Allows devices from the host system to be attached to a task container similar to using `--device` in docker. ",
           "type": "object",
+          "additionalProperties": false,
           "properties": {
             "loopbackVideo": {
               "title": "Loopback Video device",
@@ -148,6 +162,7 @@
                 "build",
                 "memory"
               ],
+              "additionalProperties": false,
               "properties": {
                 "type": {
                   "title": "Phone Type",
@@ -196,6 +211,9 @@
     "env": {
       "title": "Environment variable mappings.",
       "description": "Example: ```\n{\n  \"PATH\": '/borked/path' \n  \"ENV_NAME\": \"VALUE\" \n}\n```",
+      "additionalProperties": {
+        "type": "string"
+      },
       "type": "object"
     },
     "maxRunTime": {
@@ -210,6 +228,7 @@
       "title": "Exit status handling",
       "description": "By default docker-worker will fail a task with a non-zero exit status without retrying.  This payload property allows a task owner to define certain exit statuses that will be marked as a retriable exception.",
       "type": "object",
+      "additionalProperties": false,
       "properties": {
         "retry": {
           "title": "Retriable exit statuses",
@@ -220,7 +239,7 @@
             "type": "number"
           }
         },
-	"purgeCaches": {
+        "purgeCaches": {
           "title": "Purge caches exit status",
           "description": "If the task exists with a purge caches exit status, all caches associated with the task will be purged.",
           "type": "array",
@@ -228,12 +247,12 @@
             "title": "Exit statuses",
             "type": "number"
           }
-	}
+        }
       }
     },
     "artifacts": {
       "type": "object",
-      "title": "Artifact map (name -> source)",
+      "title": "Artifacts",
       "description": "Artifact upload map example: ```{\"public/build.tar.gz\": {\"path\": \"/home/worker/build.tar.gz\", \"expires\": \"2016-05-28T16:12:56.693817Z\", \"type\": \"file\"}}```",
       "additionalProperties": {
         "$ref": "#/definitions/artifact"
@@ -249,6 +268,7 @@
       "title": "Feature flags",
       "description": "Used to enable additional functionality.",
       "type": "object",
+      "additionalProperties": false,
       "properties": {
         "localLiveLog": {
           "type": "boolean",


### PR DESCRIPTION
This tightens the screws on the payload schema of docker-worker primarily by adding `additionalProperties` settings throughout the JSON subschemas.

This is useful for two reasons:

1) Currently additional properties can be submitted without causing a malformed payload exception, that would be ignored by docker-worker (e.g. misspelled properties) and would cause hard-to-diagnose failures for task submitters
2) It causes cleaner types to be generated by github.com/taskcluster/jsonschema2go which will simplify and improve the process of adding support for docker-worker payloads in generic-worker

See [bug 1490964](https://bugzil.la/1490964) for further context.