### PR TITLE
Bug 1508395 - update tc-lib-validate

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "taskcluster-lib-scopes": "^10.0.1",
     "taskcluster-lib-testing": "^12.1.2",
     "taskcluster-lib-urls": "^10.1.1",
-    "taskcluster-lib-validate": "11.0.2",
+    "taskcluster-lib-validate": "12.0.0",
     "taskcluster-task-factory": "^0.6.4",
     "temporary": "^0.0.8",
     "typed-env-config": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3846,7 +3846,24 @@ taskcluster-lib-urls@^10.0.0, taskcluster-lib-urls@^10.1.1:
   resolved "https://registry.yarnpkg.com/taskcluster-lib-urls/-/taskcluster-lib-urls-10.1.1.tgz#67d5b9449b947e5234eafdd15c46267dde29bf74"
   integrity sha512-tdrK++rCX73FMXk/cXwS6RLTjA3pX8hJlxg1ECLs3L3llCOPMNhQ4wi6lb6yMgHc/s5on/Edj6AlAH7gkxzgPg==
 
-taskcluster-lib-validate@11.0.2, taskcluster-lib-validate@^11.0.1:
+taskcluster-lib-validate@12.0.0:
+  version "12.0.0"
+  resolved "https://registry.yarnpkg.com/taskcluster-lib-validate/-/taskcluster-lib-validate-12.0.0.tgz#ab7b649159a7616ac09d080a42e8756be69c18a6"
+  integrity sha512-nhZzLN3oegEJ3e8iNMsvPjqeJuiq4G2iTley0F4DX/ePcQ2kF857oTNAwAyhgN67+jZ+qDQliYqNmtIAFcZ7tg==
+  dependencies:
+    ajv "^6.5.0"
+    app-root-dir "^1.0.2"
+    aws-sdk "^2.142.0"
+    debug "^3.1.0"
+    js-yaml "^3.10.0"
+    lodash "^4.5.1"
+    mkdirp "^0.5.1"
+    promise "^8.0.1"
+    rimraf "^2.6.2"
+    taskcluster-lib-urls "^1.1.0"
+    walk "^2.3.9"
+
+taskcluster-lib-validate@^11.0.1:
   version "11.0.2"
   resolved "https://registry.yarnpkg.com/taskcluster-lib-validate/-/taskcluster-lib-validate-11.0.2.tgz#e1270450c9f1e09ddd8ba2cb6be1123eac86a3a6"
   integrity sha512-Cbjzu7gMe7nguRxSr0KHVDj99EqLEJheUL7xOMD/hdXMUHOEnB0tFU7IUg27VcGLoffG0/b0nJtN6aBi2fIveA==


### PR DESCRIPTION
This should be a no-op, as docker-worker doesn't actually generate any
references or anything like that.