### PR TITLE
Use the correct userdata property for rootUrl

### DIFF
--- a/src/lib/host/aws.js
+++ b/src/lib/host/aws.js
@@ -115,6 +115,11 @@ module.exports = {
     let userdata = await getJsonData(`${baseUrl}/user-data`);
     let securityToken = userdata.securityToken;
     let rootUrl = userdata.taskclusterRootUrl;
+    if (!rootUrl) {
+      // Without a rootUrl, there's no way to claim tasks, so bail out..
+      log('[alert-operator] no rootUrl provided');
+      spawn('shutdown', ['-h', 'now']);
+    }
 
     log('read userdata', { text: userdata });
 

--- a/src/lib/host/aws.js
+++ b/src/lib/host/aws.js
@@ -114,12 +114,7 @@ module.exports = {
 
     let userdata = await getJsonData(`${baseUrl}/user-data`);
     let securityToken = userdata.securityToken;
-
-    let rootUrl = userdata.rootUrl;
-    if (!rootUrl) {
-      // for backward compatibility, assume the legacy instance if no rootUrl is given
-      rootUrl = 'https://taskcluster.net';
-    }
+    let rootUrl = userdata.taskclusterRootUrl;
 
     log('read userdata', { text: userdata });
 


### PR DESCRIPTION
Per https://bugzilla.mozilla.org/show_bug.cgi?id=1462768 this property
is named `taskclusterRootUrl`.  And since that's landed, we can remove the
default.