### PR TITLE
Whitelist the files that go into docker-worker.tgz

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,7 @@ docker-worker.tgz
 yarn-error.log
 packer-artifacts.json
 worker-types-backup.json
+image.tar.gz
+initrd.tar.gz
+kernel.tar.gz
+modules.tar.gz

--- a/Dockerfile.packet
+++ b/Dockerfile.packet
@@ -114,6 +114,6 @@ RUN tar xzf /tmp/deploy.tar.gz -C / --strip-components=1
 
 RUN mkdir -p $HOME/docker_worker
 RUN npm i -g yarn
-RUN cd $HOME/docker_worker && tar xzf /tmp/docker-worker.tgz -C . --strip-components=1 && yarn install --frozen-lockfile
+RUN cd $HOME/docker_worker && tar xzf /tmp/docker-worker.tgz -C . && yarn install --frozen-lockfile
 
 # END OF APP IMAGE

--- a/deploy/bin/build
+++ b/deploy/bin/build
@@ -33,25 +33,13 @@ tar_docker_worker() {
   local docker_worker_tgz=/tmp/docker-worker-$$.tgz
   # Package up the node app.
   tar \
-    --exclude='./node_modules' \
-    --exclude='./*.pub' \
-    --exclude='./build/' \
-    --exclude='./deploy' \
-    --exclude='.test' \
-    --exclude='.git' \
-    --exclude='.vagrant' \
-    --exclude='./.DS_Store' \
-    --exclude='./vagrant/' \
-    --exclude='app.box' \
-    --exclude='./worker-types-backup.json' \
-    --exclude='./docker-worker-amis.json' \
-    --exclude='./packer-artifacts.json' \
-    --exclude='docker-worker.tgz' \
-    --exclude='image.tar.gz' \
-    --exclude='modules.tar.gz' \
-    --exclude='kernel.tar.gz' \
-    --exclude='initrd.tar.gz' \
-    -zcvf $docker_worker_tgz .
+      -zcvf $docker_worker_tgz \
+      src/ \
+      schemas/ \
+      .npmignore \
+      package.json \
+      yarn.lock \
+      config.yml
   mv $docker_worker_tgz docker-worker.tgz
 }
 

--- a/deploy/packer/app/scripts/deploy.sh
+++ b/deploy/packer/app/scripts/deploy.sh
@@ -24,7 +24,7 @@ sudo tar xzf $template_source -C / --strip-components=1
 target=$HOME/docker_worker
 mkdir -p $target
 cd $target
-tar xzf $docker_worker_source -C $target --strip-components=1
+tar xzf $docker_worker_source -C $target
 sudo chown -R $USER:$USER /home/ubuntu/docker_worker
 
 sudo npm install -g yarn@1.0.2


### PR DESCRIPTION
With the blacklist strategy we may include sensitive data in the tgz
file.

Credits to @djmitche  for the idea.