### PR TITLE
Bug 1523264: Fix docker-worker startup on systemd

### DIFF
--- a/Dockerfile.packet
+++ b/Dockerfile.packet
@@ -116,4 +116,6 @@ RUN mkdir -p $HOME/docker_worker
 RUN npm i -g yarn
 RUN cd $HOME/docker_worker && tar xzf /tmp/docker-worker.tgz -C . && yarn install --frozen-lockfile
 
+RUN ln -sf /usr/lib/systemd/system/docker-worker.service /etc/systemd/system/multi-user.target.wants/docker-worker.service
+
 # END OF APP IMAGE

--- a/deploy/template/etc/systemd/system/multi-user.target.wants/docker-worker.service
+++ b/deploy/template/etc/systemd/system/multi-user.target.wants/docker-worker.service
@@ -1,1 +1,0 @@
-/lib/systemd/system/docker-worker.service


### PR DESCRIPTION
tar doesn't pack symbolic links, so it doesn't include the symbolic link
of the docker-worker service in /etc/systemd/system, which turns it in a
disabled service.

We fix this by creating the symbolic link during image building inside
the Dockerfile.