### PR TITLE
Bug 1439110: Omit accessToken from Papertrail logs

### DIFF
--- a/src/lib/features/taskcluster_proxy.js
+++ b/src/lib/features/taskcluster_proxy.js
@@ -105,7 +105,7 @@ class TaskclusterProxy {
             task.runtime.log('Credentials updated', {
               taskId: task.status.taskId,
               runId: task.runId,
-              credentials: creds
+              clientId: creds.clientId,
             });
             accept();
           } else {


### PR DESCRIPTION
Papertrail logs are restrict to core members, but even so let's harden
it.