### PR TITLE
Bug 1531208: Add bin-utils to the AMI

### DIFF
--- a/deploy/bin/build
+++ b/deploy/bin/build
@@ -39,7 +39,8 @@ tar_docker_worker() {
       .npmignore \
       package.json \
       yarn.lock \
-      config.yml
+      config.yml \
+      bin-utils
   mv $docker_worker_tgz docker-worker.tgz
 }
 


### PR DESCRIPTION
If we don't, we can't run interactive tasks.