### PR TITLE
Bug 1531320 - Update password store secrets (git pull) in deploy script

### DIFF
--- a/deploy/bin/import-docker-worker-secrets
+++ b/deploy/bin/import-docker-worker-secrets
@@ -19,6 +19,8 @@ else
     echo '(no passphrase set)'
 fi
 
+pass git pull
+
 echo 'decrypting..'
 pass show docker-worker/shared-env-var-key > $base_dir/docker-worker.key
 chmod 0600 $base_dir/docker-worker.key


### PR DESCRIPTION
This is rather simple, it doesn't do a `git clean` or `git reset` in case there are local changes that people are working on, but it seems sane to do at least a `git pull` to make sure the secrets are the latest (as it is easy to forget to refresh them when deploying).

See [bug 1531320](https://bugzil.la/1531320) for details.