### PR TITLE
fix papertrail md5 check

### DIFF
--- a/deploy/packer/app/scripts/deploy.sh
+++ b/deploy/packer/app/scripts/deploy.sh
@@ -2,7 +2,7 @@
 
 ## Get recent CA bundle for papertrail
 sudo curl -o /etc/papertrail-bundle.pem https://papertrailapp.com/tools/papertrail-bundle.pem
-md5=md5sum /etc/papertrail-bundle.pem | awk '{ print $1 }'
+md5=`md5sum /etc/papertrail-bundle.pem | awk '{ print $1 }'`
 if [ "$md5" != "2c43548519379c083d60dd9e84a1b724" ]; then
     echo "md5 for papertrail CA bundle does not match"
     exit -1


### PR DESCRIPTION
Suspicion is that adding quotes to line 6 turned this from a silent failure into a real failure..