### PR TITLE
bug 1545760 - forward syslogs to moco papertrail

### DIFF
--- a/Dockerfile.packet
+++ b/Dockerfile.packet
@@ -6,7 +6,7 @@ LABEL Description="docker-worker packet image" Vendor="Mozilla"
 
 ENV DEBIAN_FRONTEND noninteractive
 
-ENV PAPERTRAIL logs2.papertrailapp.com:22395
+ENV PAPERTRAIL logs.papertrailapp.com:52806
 
 COPY ./deploy/packer/base/scripts/configure_syslog.sh /tmp/
 COPY ./deploy/packer/base/scripts/node.sh /tmp/


### PR DESCRIPTION
this change is to sync the docker worker papertrail destination with the one used by generic worker