### PR TITLE
Bug 1534672 - disable error reporting and metrics

### DIFF
--- a/src/bin/worker.js
+++ b/src/bin/worker.js
@@ -162,7 +162,7 @@ program.parse(process.argv);
   let monitor = await monitoring({
     rootUrl: config.rootUrl,
     projectName: config.monitorProject,
-    credentials: config.taskcluster,
+    enable: false,
     mock: profile === 'test',
     reportUsage: false
   });


### PR DESCRIPTION
This leaves all of the `monitor.count`, etc. in place.  I could remove those if you'd prefer but it seems a more dangerous change.

I deployed this in staging and saw much cleaner logs from workers -- they no longer try to connect to auth to get statsum and signalfx tokens.