### PR TITLE
Bug 1552617 - use instance name for worker-id

### DIFF
--- a/src/lib/host/gcp.js
+++ b/src/lib/host/gcp.js
@@ -82,7 +82,7 @@ module.exports = {
       host: instanceData.hostname,
       publicIp: instanceData.networkInterfaces[0].accessConfigs[0].externalIp,
       privateIp: instanceData.networkInterfaces[0].ip,
-      workerId: instanceData.id.toString(),
+      workerId: instanceData.name,
       workerGroup: zone,
       workerNodeType: instanceType,
       instanceId: instanceData.id.toString(),


### PR DESCRIPTION
the instance worker id is being rounded at some point in its journey to the queue. if we use the instance name (which is prefixed with "vm-"), it should prevent integer rounding by virtue of being an obvious string.