### PR TITLE
Bug 1545308: Run packet instances with performance CPU governor 

### DIFF
--- a/Dockerfile.packet
+++ b/Dockerfile.packet
@@ -117,8 +117,6 @@ RUN mkdir -p /home/ubuntu/docker_worker
 RUN npm i -g yarn
 RUN cd /home/ubuntu/docker_worker && tar xzf /tmp/docker-worker.tgz -C . && yarn install --frozen-lockfile
 
-RUN ln -sf /usr/lib/systemd/system/docker-worker.service /etc/systemd/system/multi-user.target.wants/docker-worker.service
-
 COPY ./deploy/packet-net/docker-worker.service /lib/systemd/system/docker-worker.service
 RUN systemctl enable docker-worker
 

--- a/deploy/packet-net/docker-worker.service
+++ b/deploy/packet-net/docker-worker.service
@@ -3,7 +3,7 @@ Description=Taskcluster docker worker
 After=docker.service
 
 [Service]
-Type=notify
+Type=simple
 ExecStart=/usr/local/bin/start-docker-worker
 User=root
 Environment="HOST=packet"

--- a/deploy/template/lib/systemd/set-cpufreq
+++ b/deploy/template/lib/systemd/set-cpufreq
@@ -1,0 +1,51 @@
+#! /bin/sh
+# Set the CPU Frequency Scaling governor to "ondemand"/"powersave" where available
+set -eu
+
+FIRSTCPU=`cut -f1 -d- /sys/devices/system/cpu/online`
+AVAILABLE="/sys/devices/system/cpu/cpu$FIRSTCPU/cpufreq/scaling_available_governors"
+DOWN_FACTOR="/sys/devices/system/cpu/cpufreq/ondemand/sampling_down_factor"
+
+[ -f $AVAILABLE ] || exit 0
+
+read governors < $AVAILABLE
+case $governors in
+        *performance*)
+                GOVERNOR="performance"
+                break
+                ;;
+        *interactive*)
+                GOVERNOR="interactive"
+                break
+                ;;
+        *ondemand*)
+                GOVERNOR="ondemand"
+                case $(uname -m) in
+                        ppc64*)
+                                SAMPLING=100
+                        ;;
+                esac
+                break
+                ;;
+        *powersave*)
+                GOVERNOR="powersave"
+                break
+                ;;
+        *)
+                exit 0
+                ;;
+esac
+
+[ -n "${GOVERNOR:-}" ] || exit 0
+
+echo "Setting $GOVERNOR scheduler for all CPUs"
+
+for CPUFREQ in /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor
+do
+        [ -f $CPUFREQ ] || continue
+        echo -n $GOVERNOR > $CPUFREQ
+done
+if [ -n "${SAMPLING:-}" ] && [ -f $DOWN_FACTOR ]; then
+        echo -n $SAMPLING > $DOWN_FACTOR
+fi
+


### PR DESCRIPTION
By default, the CPU governor is set to powersave, and the cores can run
in very low frequencies. Setting to performance makes the cores run at
their maximum frequencies.