### PR TITLE
Bug 1558530, 1546686 - run under tc-worker-runner

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -61,6 +61,9 @@ defaults:
 
   alivenessCheckInterval: 30000
 
+  # by default, run one task at a time
+  capacity: 1
+
   capacityManagement:
     diskspaceThreshold: 10000000000
 

--- a/deploy/packer/app/scripts/deploy.sh
+++ b/deploy/packer/app/scripts/deploy.sh
@@ -47,6 +47,19 @@ docker pull taskcluster/livelog:v4
 docker pull taskcluster/dind-service:v4.0
 docker pull taskcluster/relengapi-proxy:$relengapi_proxy_version
 
+# install and configure taskcluster-worker-runner
+sudo curl --fail -L -o /usr/local/bin/start-worker https://github.com/taskcluster/taskcluster-worker-runner/releases/download/v0.2.1/start-worker-linux-amd64
+file /usr/local/bin/start-worker
+sudo chmod +x /usr/local/bin/start-worker
+sudo bash -c 'cat > /etc/start-worker.yml <<EOF
+provider:
+    providerType: aws-provisioner
+worker:
+    implementation: docker-worker
+    path: /home/ubuntu/docker_worker
+    configPath: /home/ubuntu/worker.cfg
+EOF'
+
 # Reboot the machine on OOM
 # Ref: http://www.oracle.com/technetwork/articles/servers-storage-dev/oom-killer-1911807.html
 sudo sh -c 'echo "vm.panic_on_oom=1" >> /etc/sysctl.conf'

--- a/deploy/packer/app/scripts/deploy.sh
+++ b/deploy/packer/app/scripts/deploy.sh
@@ -1,5 +1,11 @@
 #! /bin/bash -vex
 
+relengapi_proxy_version=2.3.1
+taskcluster_proxy_version=5.1.0
+livelog_version=4
+dind_service_version=4.0
+worker_runner_version=0.2.1
+
 ## Get recent CA bundle for papertrail
 sudo curl -o /etc/papertrail-bundle.pem https://papertrailapp.com/tools/papertrail-bundle.pem
 md5=`md5sum /etc/papertrail-bundle.pem | awk '{ print $1 }'`
@@ -39,17 +45,14 @@ sudo modprobe snd-aloop
 # Create dependency file
 sudo depmod
 
-relengapi_proxy_version=2.3.1
-
 # Pull images used for sidecar containers
-docker pull taskcluster/taskcluster-proxy:5.1.0
-docker pull taskcluster/livelog:v4
-docker pull taskcluster/dind-service:v4.0
+docker pull taskcluster/taskcluster-proxy:$taskcluster_proxy_version
+docker pull taskcluster/livelog:v$livelog_version
+docker pull taskcluster/dind-service:v$dind_service_version
 docker pull taskcluster/relengapi-proxy:$relengapi_proxy_version
 
 # install and configure taskcluster-worker-runner
-sudo curl --fail -L -o /usr/local/bin/start-worker https://github.com/taskcluster/taskcluster-worker-runner/releases/download/v0.2.1/start-worker-linux-amd64
-file /usr/local/bin/start-worker
+sudo curl --fail -L -o /usr/local/bin/start-worker https://github.com/taskcluster/taskcluster-worker-runner/releases/download/v$worker_runner_version/start-worker-linux-amd64
 sudo chmod +x /usr/local/bin/start-worker
 sudo bash -c 'cat > /etc/start-worker.yml <<EOF
 provider:
@@ -66,7 +69,12 @@ sudo sh -c 'echo "vm.panic_on_oom=1" >> /etc/sysctl.conf'
 sudo sh -c 'echo "kernel.panic=1" >> /etc/sysctl.conf'
 
 # Export the images as a tarball to load when insances are initialized
-docker save taskcluster/taskcluster-proxy:5.1.0 taskcluster/livelog:v4 taskcluster/dind-service:v4.0 taskcluster/relengapi-proxy:$relengapi_proxy_version > /home/ubuntu/docker_worker/docker_worker_images.tar
+docker save \
+    taskcluster/taskcluster-proxy:$taskcluster_proxy_version \
+    taskcluster/livelog:v$livelog_version \
+    taskcluster/dind-service:v$dind_service_version \
+    taskcluster/relengapi-proxy:$relengapi_proxy_version \
+    > /home/ubuntu/docker_worker/docker_worker_images.tar
 
 sudo bash -c 'cat > /lib/systemd/system/docker-worker.service <<EOF
 [Unit]

--- a/deploy/template/usr/local/bin/start-docker-worker
+++ b/deploy/template/usr/local/bin/start-docker-worker
@@ -1,6 +1,3 @@
 #!/bin/bash -vex
 
-DOCKER_WORKER='node /home/ubuntu/docker_worker/src/bin/worker.js'
-DOCKER_WORKER_OPTS=
-
-$DOCKER_WORKER $DOCKER_WORKER_OPTS --host $HOST production 2>&1 | logger --tag docker-worker
+/usr/local/bin/start-worker /etc/start-worker.yml 2>&1 | logger --tag docker-worker

--- a/src/bin/worker.js
+++ b/src/bin/worker.js
@@ -27,7 +27,7 @@ const typedEnvConfig = require('typed-env-config');
 const SchemaSet = require('taskcluster-lib-validate');
 
 // Available target configurations.
-var allowedHosts = ['aws', 'test', 'packet'];
+var allowedHosts = ['aws', 'test', 'packet', 'taskcluster-worker-runner'];
 let debug = Debug('docker-worker:bin:worker');
 
 // All overridable configuration options from the CLI.
@@ -75,16 +75,7 @@ function o() {
 
 // Usage.
 program.usage(
-  '[options] <profile> \n\n' +
-'  Configuration is loaded in the following order (lower down overrides): ' +
-'\n\n' +
-'      1. docker-worker/config/defaults \n' +
-'      2. docker-worker/config/<profile> \n' +
-'      3. $PWD/docker-worker.conf.json \n' +
-'      4. ~/docker-worker.conf.json \n' +
-'      5. /etc/docker-worker.conf.json \n' +
-'      6. Host specific configuration (userdata, test data, etc..) \n' +
-'      7. Command line flags (capacity, workerId, etc...)'
+  '[options] <profile>'
 );
 
 // CLI Options.

--- a/src/bin/worker.js
+++ b/src/bin/worker.js
@@ -123,6 +123,10 @@ program.parse(process.argv);
 
     host = require('../lib/host/' + program.host);
 
+    if (host.setup) {
+      host.setup();
+    }
+
     // execute the configuration helper and merge the results
     var targetConfig = await host.configure();
     config = _.defaultsDeep(targetConfig, config);

--- a/src/lib/host/taskcluster-worker-runner.js
+++ b/src/lib/host/taskcluster-worker-runner.js
@@ -1,0 +1,21 @@
+const fs = require('fs');
+const os = require('os');
+
+module.exports = {
+  billingCycleUptime() {
+    return os.uptime();
+  },
+
+  getTerminationTime() {
+    return '';
+  },
+
+  configure() {
+    const configFile = process.env.DOCKER_WORKER_CONFIG;
+    if (!configFile || !fs.existsSync(configFile)) {
+      throw new Error('No config file found');
+    }
+    const content = fs.readFileSync(configFile, 'utf8');
+    return JSON.parse(content);
+  }
+};

--- a/src/lib/host/taskcluster-worker-runner.js
+++ b/src/lib/host/taskcluster-worker-runner.js
@@ -1,7 +1,18 @@
 const fs = require('fs');
 const os = require('os');
+const {StreamTransport, Protocol} = require('../worker-runner-protocol');
+
+// This module is imported as an "object", so the only place we have to store
+// persistent state is as module-level globals.
+let protocol;
 
 module.exports = {
+  setup() {
+    const transp = new StreamTransport(process.stdin, process.stdout);
+    protocol = new Protocol(transp, new Set([
+    ]));
+  },
+
   billingCycleUptime() {
     return os.uptime();
   },

--- a/src/lib/worker-runner-protocol.js
+++ b/src/lib/worker-runner-protocol.js
@@ -1,0 +1,51 @@
+const {EventEmitter} = require('events');
+const split2 = require('split2');
+
+/**
+ * This is an implementation of the worker-runner protocol documented at
+ * https://github.com/taskcluster/taskcluster-worker-runner/blob/master/protocol.md
+ */
+
+/**
+ * A transport should have a `send(message)` method to send messages,
+ * and should emit a `message` event when one is received.  Since this
+ * implements only the worker side of the protocol, invalid lines are
+ * simply ignored.
+ *
+ * StreamTransport implements this interface using Node streams.
+ */
+class StreamTransport extends EventEmitter {
+  constructor(input, output) {
+    super();
+
+    // line-buffer the input and react to individual messages
+    const lines = input.pipe(split2());
+
+    lines.on('data', line => {
+      if (!line.startsWith('~{') || !line.endsWith('}')) {
+        return;
+      }
+      let msg;
+      try {
+        msg = JSON.parse(line.slice(1));
+      } catch (err) {
+        return;
+      }
+      if (!msg.type) {
+        return;
+      }
+      this.emit('message', msg);
+    });
+
+    // emit end as well when the input closes, for testing purposes
+    lines.on('end', () => this.emit('end'));
+
+    this.output = output;
+  }
+
+  send(message) {
+    this.output.write('~' + JSON.stringify(message) + '\n');
+  }
+}
+
+exports.StreamTransport = StreamTransport;

--- a/test/worker-runner-protocol_test.js
+++ b/test/worker-runner-protocol_test.js
@@ -1,0 +1,72 @@
+const assert = require('assert');
+const {Readable, PassThrough} = require('stream');
+const {StreamTransport} = require('../src/lib/worker-runner-protocol');
+
+const endEvent = emitter => new Promise(resolve => emitter.on('end', resolve));
+
+suite('worker-runner-protocol', function() {
+  suite('transport', function() {
+    test('receive', async function() {
+      const messages = [];
+      const input = new Readable();
+      const output = new PassThrough();
+      const sp = new StreamTransport(input, output);
+      sp.on('message', msg => messages.push(msg));
+      const end = endEvent(sp);
+
+      // streams do all manner of buffering internally, so we can't test that
+      // here.  However, empirically when the input is stdin, that buffering
+      // is disabled and we get new lines immediately.
+      input.push('ignored line\n');
+      input.push('~{"type": "test"}\n');
+      input.push('~{"xxx": "yyy"}\n'); // also ignored: no type
+      input.push('~{"xxx", "yyy"}\n'); // also ignored: invalid JSON
+      input.push(null);
+
+      input.destroy();
+      output.destroy();
+
+      await end;
+
+      assert.deepEqual(messages, [{type: 'test'}]);
+    });
+
+    test('send', async function() {
+      const written = [];
+      const input = new Readable();
+      const output = new PassThrough();
+      const sp = new StreamTransport(input, output);
+      output.on('data', chunk => written.push(chunk));
+
+      sp.send({type: 'test'});
+      sp.send({type: 'test-again'});
+
+      input.destroy();
+      output.destroy();
+
+      assert.deepEqual(written.join(''), '~{"type":"test"}\n~{"type":"test-again"}\n');
+    });
+
+    test('bidirectional', async function() {
+      const leftward = new PassThrough();
+      const rightward = new PassThrough();
+      const left = new StreamTransport(leftward, rightward);
+      const right = new StreamTransport(rightward, leftward);
+
+      const leftMessages = [];
+      left.on('message', msg => leftMessages.push(msg));
+
+      const rightMessages = [];
+      right.on('message', msg => rightMessages.push(msg));
+
+      left.send({type: 'from-left'});
+      right.send({type: 'from-right'});
+
+      leftward.destroy();
+      rightward.destroy();
+
+      assert.deepEqual(leftMessages, [{type: 'from-right'}]);
+      assert.deepEqual(rightMessages, [{type: 'from-left'}]);
+    });
+  });
+});


### PR DESCRIPTION
This includes #464. 

This is about all of the "protocol" we'll ever support in docker-worker, but does bring the tc-worker-runner "host" up to the same functionality level as the other hosts (specifically, supporting spot-instance shutdown).