### PR TITLE
Fix image building

### DIFF
--- a/deploy/packer/app.json
+++ b/deploy/packer/app.json
@@ -62,10 +62,6 @@
       "inline": [
         "/tmp/deploy.sh /tmp/deploy.tar.gz /tmp/docker-worker.tgz"
       ]
-    },
-    {
-      "type":           "shell",
-      "inline":         ["sudo unattended-upgrade"]
     }
   ],
   "builders": [

--- a/deploy/packer/base.json
+++ b/deploy/packer/base.json
@@ -36,10 +36,6 @@
       ]
     },
     {
-      "type":           "shell",
-      "inline":         ["sudo unattended-upgrade"]
-    },
-    {
       "type": "shell",
       "inline": [
         "sudo bash -c 'echo net.ipv4.tcp_challenge_ack_limit = 999999999 >> /etc/sysctl.conf'"

--- a/deploy/packer/base/scripts/packages.sh
+++ b/deploy/packer/base/scripts/packages.sh
@@ -61,7 +61,7 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install -yq \
     dkms
 
 ## Install all the packages
-sudo apt-get install -yq \
+sudo DEBIAN_FRONTEND=noninteractive apt-get install -yq \
     docker-ce=$DOCKER_VERSION \
     lvm2 \
     curl \


### PR DESCRIPTION
Don't ask me why, but unattended-upgrade is failing by the end of the
provisioner script. As it is no longer needed since we call it earlier,
let's remove it.

Also install packages in "noninteractive" mode.