### PR TITLE
Bug 1522850: workaround for drivers loading issue

### DIFF
--- a/Dockerfile.packet
+++ b/Dockerfile.packet
@@ -119,5 +119,6 @@ RUN cd /home/ubuntu/docker_worker && tar xzf /tmp/docker-worker.tgz -C . && yarn
 
 COPY ./deploy/packet-net/docker-worker.service /lib/systemd/system/docker-worker.service
 RUN systemctl enable docker-worker
+RUN systemctl enable device-drivers
 
 # END OF APP IMAGE

--- a/deploy/packet-net/docker-worker.service
+++ b/deploy/packet-net/docker-worker.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Taskcluster docker worker
-After=docker.service
+Wants=device-drivers
+After=docker.service device-drivers
 
 [Service]
 Type=simple

--- a/deploy/template/lib/systemd/system/device-drivers.service
+++ b/deploy/template/lib/systemd/system/device-drivers.service
@@ -1,0 +1,17 @@
+# This is required because of a bug in packet.net that overwrites
+# our /etc/modules files during image deployment
+#
+# Adding it to other cloud providers is redundant, but not harmful
+
+[Unit]
+Description=Load the v4l2loopback and sndloop drivers
+
+[Service]
+Type=notify
+NotifyAccess=all
+TimeoutStartSec=300
+ExecStart=/usr/local/bin/load-drivers
+User=root
+
+[Install]
+RequiredBy=docker-worker.service

--- a/deploy/template/usr/local/bin/load-drivers
+++ b/deploy/template/usr/local/bin/load-drivers
@@ -1,0 +1,6 @@
+#!/bin/sh -vex
+
+modprobe v4l2loopback
+modprobe snd-aloop
+
+systemd-notify --ready

--- a/deploy/template/usr/local/bin/load-side-containers
+++ b/deploy/template/usr/local/bin/load-side-containers
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/sh -vex
 
 docker load -i /home/ubuntu/docker_worker/docker_worker_images.tar
 systemd-notify --ready

--- a/deploy/template/usr/local/bin/start-docker-worker
+++ b/deploy/template/usr/local/bin/start-docker-worker
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -vex
 
 DOCKER_WORKER='node /home/ubuntu/docker_worker/src/bin/worker.js'
 DOCKER_WORKER_OPTS=


### PR DESCRIPTION
We add v4l2loopback and snd-aloop to /etc/modules, but packet overwrites
it during deployment. We workaround it by loading the drivers through
systemd.

We also add the vex options to the bash scripts to improve systemd logs.