### PR TITLE
Configure providerType per cloud

### DIFF
--- a/deploy/bin/build
+++ b/deploy/bin/build
@@ -95,6 +95,7 @@ cmd_app() {
     -var "templateContents=deploy/deploy.tar.gz" \
     -var "npmPackage=docker-worker.tgz" \
     -var "workerRevision=$git_rev" \
+    -var "deployment=$DEPLOYMENT" \
     -var "hvmSourceAMI=$hvmSourceAMI" \
     -var "gcpProjectId=$GCP_PROJECT_ID" \
     -var "gcpSourceImage=$gcpSourceImage" \
@@ -118,6 +119,7 @@ cmd_base() {
     $only \
     -var-file $(template_vars base) \
     -var "workerRevision=$git_rev" \
+    -var "deployment=$DEPLOYMENT" \
     -var "gcpProjectId=$GCP_PROJECT_ID" \
     $(packer_config base)
 }

--- a/deploy/packer/app.json
+++ b/deploy/packer/app.json
@@ -3,6 +3,7 @@
 
   "variables": {
     "npmPackage":          "",
+    "deployment":          "",
     "templateContents":    "",
     "hvmSourceAMI":        "",
     "gcpSourceImage":      "",
@@ -62,14 +63,14 @@
     {
       "type":           "shell",
       "inline": [
-        "/tmp/deploy.sh /tmp/deploy.tar.gz /tmp/docker-worker.tgz aws"
+        "/tmp/deploy.sh /tmp/deploy.tar.gz /tmp/docker-worker.tgz aws {{user `deployment`}}"
       ],
       "only":           ["hvm-builder-trusted", "hvm-builder"]
     },
     {
       "type":           "shell",
       "inline": [
-        "/tmp/deploy.sh /tmp/deploy.tar.gz /tmp/docker-worker.tgz gcp"
+        "/tmp/deploy.sh /tmp/deploy.tar.gz /tmp/docker-worker.tgz gcp {{user `deployment`}}"
       ],
       "only":           ["gcp"]
     }

--- a/deploy/packer/base.json
+++ b/deploy/packer/base.json
@@ -1,6 +1,7 @@
 {
   "description": "taskcluster worker system dependencies",
   "variables": {
+    "deployment":             "",
     "papertrail":             "",
     "privateKeyLocation":     "",
     "sslKeyLocation":         "",


### PR DESCRIPTION
This uses a slighlty different tc-worker-runner config per cloud (with a special one for the legacy/production deployment).  Aside from a likely few version bumps of tc-worker-runner, this should be the last patch I need to make to docker-worker.