### PR TITLE
Remove the backup file from github releases

### DIFF
--- a/deploy/bin/github-release.js
+++ b/deploy/bin/github-release.js
@@ -66,7 +66,7 @@ function uploadFile(github, filename) {
 function main() {
   const github = signin();
   createRelease(github)
-    .then(() => uploadFile(github, 'worker-types-backup.json'))
+    .then(() => uploadFile(github, 'docker-worker.tgz'))
     .then(() => uploadFile(github, 'docker-worker-amis.json'))
     .then(() => console.log(RELEASE_NAME))
     .catch(err => {


### PR DESCRIPTION
Since [ci-admin](https://hg.mozilla.org/ci/ci-admin) and
[ci-configuration](https://hg.mozilla.org/ci/ci-configuration/) now
handle worker types update, we no longer have a backup file. Instead, we
upload the docker-worker.tgz file containing the source code of the
worker that runs in the goes in the AMI.