### PR TITLE
Bug 1569856: Provide a default disk limit for volume cache

### DIFF
--- a/src/lib/host/taskcluster-worker-runner.js
+++ b/src/lib/host/taskcluster-worker-runner.js
@@ -37,6 +37,10 @@ module.exports = {
       throw new Error('No config file found');
     }
     const content = fs.readFileSync(configFile, 'utf8');
-    return JSON.parse(content);
+    return Object.assign({
+      capacityManagement: {
+        diskspaceThreshold: 30000000000,
+      },
+    }, JSON.parse(content));
   }
 };


### PR DESCRIPTION
If the work types has disk limit configuration for volume caches, it may
grows up to let the system out of space.