### PR TITLE
Bug 1570203 - just use 'localhost' for livelogs when no stateless DNS

### DIFF
--- a/src/lib/util/hostname.js
+++ b/src/lib/util/hostname.js
@@ -3,15 +3,13 @@ const statelessDNSServer = require('stateless-dns-server');
 
 module.exports = function getHostname(config, expires) {
   let statelessConfig = config.statelessHostname || {};
-  if (!statelessConfig || !statelessConfig.enabled) {
+  if (!statelessConfig || !statelessConfig.secret || !statelessConfig.domain) {
     return config.host;
   }
 
-  let secret = statelessConfig.secret || '';
-  let domain = statelessConfig.domain || '';
+  let secret = statelessConfig.secret;
+  let domain = statelessConfig.domain;
   let ip = config.publicIp;
-  assert(secret, 'Must supply a secret for stateless dns server');
-  assert(domain, 'Must supply a domain name used for stateless hostname');
   assert(ip, 'Public IP is not specified in the configuration');
 
   let hostname;


### PR DESCRIPTION
This will make a `live.log` that sends users' browsers on a wild goose chase, but it's an OK change for now.

We may need to consider rewriting the whole live log feature to support websocktunnel, but that's a much bigger project.