### PR TITLE
Run packet.net instance with taskcluster-worker-runner

### DIFF
--- a/Dockerfile.packet
+++ b/Dockerfile.packet
@@ -1,4 +1,4 @@
-FROM ubuntu_18_04-base
+FROM taskcluster/ubuntu_18_04-base
 MAINTAINER Wander Lairson Costa <wcosta@mozilla.com>
 LABEL Description="docker-worker packet.net image" Vendor="Mozilla"
 
@@ -35,11 +35,10 @@ RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - \
 	&& add-apt-repository \
    "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
    $(lsb_release -cs) \
-   stable" \
-	&& apt-get update
+   stable"
 
+RUN apt-get update
 RUN apt-get install -yq \
-    unattended-upgrades \
     docker-ce=18.06.0~ce~3-0~ubuntu \
     lvm2 \
     build-essential \
@@ -63,6 +62,7 @@ RUN apt-get install -yq \
     liblz4-tool \
 	linux-image-generic \
 	linux-headers-generic \
+	python3-systemd \
 	dkms
 
 RUN apt-get purge -yq apport
@@ -95,7 +95,7 @@ RUN chmod +x /etc/rc.local
 RUN echo net.ipv4.tcp_challenge_ack_limit = 999999999 >> /etc/sysctl.conf
 
 RUN apt-get autoremove -y
-RUN unattended-upgrade
+RUN apt-get upgrade -yq
 
 RUN /tmp/node.sh
 
@@ -113,11 +113,20 @@ RUN apt-get install -y python-statsd
 
 RUN tar xzf /tmp/deploy.tar.gz -C / --strip-components=1
 
+RUN mkdir -p /mnt/docker-tmp
+
 RUN mkdir -p /home/ubuntu/docker_worker
 RUN npm i -g yarn
 RUN cd /home/ubuntu/docker_worker && tar xzf /tmp/docker-worker.tgz -C . && yarn install --frozen-lockfile
 
+# install and configure taskcluster-worker-runner
+RUN curl --fail -L -o /usr/local/bin/start-worker https://github.com/taskcluster/taskcluster-worker-runner/releases/download/v0.3.2/start-worker-linux-amd64
+RUN chmod +x /usr/local/bin/start-worker
+
 COPY ./deploy/packet-net/docker-worker.service /lib/systemd/system/docker-worker.service
+COPY ./deploy/packet-net/tc-w-runner-config.service /lib/systemd/system/tc-w-runner-config.service
 RUN systemctl enable docker-worker
 RUN systemctl enable device-drivers
+RUN systemctl enable tc-w-runner-config.service
+
 # END OF APP IMAGE

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
   - [Deployment](#deployment)
     - [Requirements](#requirements-1)
     - [Building AMI's](#building-amis)
+    - [Packet.net deployment](#packetnet-deployment)
     - [Block-Device Mapping](#block-device-mapping)
     - [Updating Schema](#updating-schema)
     - [Post-Deployment Verification](#post-deployment-verification)
@@ -291,8 +292,20 @@ folders.
 
 ### Packet.net deployment
 
-To generate the packet.net image, you need the `ubuntu_18_04-base` docker
-image. You obtain this image, clone the
+To generate a new custom image, just type from the docker-worker repo root
+directory:
+
+```
+deploy/bin/build packet
+```
+
+You can find information on how to deploy the custom image in the
+[packet website](https://support.packet.com/kb/articles/custom-images).
+
+#### Base image
+
+To generate the packet.net image, you need the `taskcluster/ubuntu_18_04-base:latest` docker
+image. If you need to build this image, clone the
 [packet-images](https://github.com/packethost/packet-images), and run (you may
 need to run the command twice):
 
@@ -302,14 +315,11 @@ $ sudo ./tools/build.sh -d ubuntu_18_04 -p t1.small.x86 -a x86_64 -b ubuntu_18_0
 
 You will need a valid Github ssh key in the root/.ssh directory.
 
-Then, run:
+Then just tag it with the `taskcluster/` prefix:
 
 ```
-deploy/bin/build packet
+$ docker tag ubuntu_18_04-base:latest taskcluster/ubuntu_18_04-base:latest
 ```
-
-You can find information on how to deploy the custom image in the
-[packet website](https://support.packet.com/kb/articles/custom-images).
 
 ### Block-Device Mapping
 

--- a/config.yml
+++ b/config.yml
@@ -48,6 +48,10 @@ defaults:
   # Run test only teardown and logging events.
   testMode: false
 
+  workerNodeType: 'standalone'
+  instanceId: 'standalone'
+  region: 'none'
+
   # Run each container in as restrict fashion as possible (one core per container)
   # When this is true the capacity is always overriden to the number of cores.
   restrictCPU: false

--- a/deploy/packet-net/docker-worker.service
+++ b/deploy/packet-net/docker-worker.service
@@ -1,13 +1,12 @@
 [Unit]
 Description=Taskcluster docker worker
-Wants=device-drivers
-After=docker.service device-drivers
+Wants=device-drivers.service tc-w-runner-config.service
+After=docker.service device-drivers.service tc-w-runner-config.service
 
 [Service]
 Type=simple
 ExecStart=/usr/local/bin/start-docker-worker
 User=root
-Environment="HOST=packet"
 
 [Install]
 RequiredBy=graphical.target

--- a/deploy/packet-net/tc-w-runner-config.service
+++ b/deploy/packet-net/tc-w-runner-config.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Creates the /etc/start-worker.yml file
+Wants=cloud-init.target
+After=cloud-init.target
+
+[Service]
+Type=notify
+ExecStart=/usr/local/bin/load-packet-config
+User=root
+
+[Install]
+RequiredBy=docker-worker.service

--- a/deploy/template/usr/local/bin/load-packet-config
+++ b/deploy/template/usr/local/bin/load-packet-config
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+
+import requests
+import systemd.daemon
+
+def main():
+    udf = '/var/lib/cloud/instance/user-data.txt'
+
+    r = requests.get('https://metadata.packet.net/metadata')
+    # We probably aren't in packet if we don't get a 200
+    if r.status_code != 200:
+        return
+    metadata = r.json()
+
+    userdata = filter(lambda x: len(x) == 2, (x[1:].split('=') for x in open(udf).readlines()))
+    userdata = {a:b for a,b in userdata}
+
+    with open('/etc/start-worker.yml', 'w') as f:
+        f.write(
+f'''
+provider:
+    providerType: standalone
+    rootURL: {userdata['taskclusterRootUrl']}
+    clientID: {userdata['clientId']}
+    accessToken: {userdata['accessToken']}
+    workerPoolID: {userdata['workerPoolId']}
+    workerGroup: packet-{metadata['facility']}
+    workerID: {metadata['id']}
+worker:
+    implementation: docker-worker
+    path: /home/ubuntu/docker_worker
+    configPath: /home/ubuntu/worker.cfg
+'''
+        )
+
+if __name__ == '__main__':
+    main()
+    systemd.daemon.notify('READY=1')


### PR DESCRIPTION
As worker-manager isn't production ready yet, we run packet.net image
instances through standalone provider.

We have a new `tc-w-runner-config` systemd service that creates the
`/etc/start-worker.yml` file.

Notice the image doesn't ship with the SSL certificate, which means that
if the option `secureLiveLogging` is true, the worker won't pick any
task to execute.

Finally, the `ubuntu_18_04-base` image is now stored in the
`docker.io/taskcluser` docker namespace, avoiding the need for building
the base image before creating a new docker packet image.