### PR TITLE
Bug 1569856: Raise the volume cache disk limit

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -206,7 +206,7 @@ test:
     volumeCachePath: '/tmp/test-cache'
 
   capacityManagement:
-    diskspaceThreshold: 1000000000
+    diskspaceThreshold: 3000000000
 
   dockerVolume: '/tmp'
 


### PR DESCRIPTION
This avoids instances accidently reaching full disk usage.