### PR TITLE
Shutdown instance on worker exit

### DIFF
--- a/deploy/template/usr/local/bin/start-docker-worker
+++ b/deploy/template/usr/local/bin/start-docker-worker
@@ -1,3 +1,5 @@
 #!/bin/bash -vex
 
 /usr/local/bin/start-worker /etc/start-worker.yml 2>&1 | logger --tag docker-worker
+echo "Worker exited. Shutting down..." | logger --tag docker-worker
+shutdown -h now


### PR DESCRIPTION
The worker should run for the entire instance life. If it exits sooner,
it means something has gone wrong. In this case, we turn off the
instance and wait for the provisioner to kill it.