### PR TITLE
Bug 1572236: Add TASKCLUSTER_WORKER_LOCATION env variable

### DIFF
--- a/deploy/packer/app/scripts/deploy.sh
+++ b/deploy/packer/app/scripts/deploy.sh
@@ -16,7 +16,7 @@ relengapi_proxy_version=2.3.1
 taskcluster_proxy_version=5.1.0
 livelog_version=4
 dind_service_version=4.0
-worker_runner_version=0.5.2
+worker_runner_version=0.5.3
 
 ## Get recent CA bundle for papertrail
 sudo curl -o /etc/papertrail-bundle.pem https://papertrailapp.com/tools/papertrail-bundle.pem

--- a/src/lib/task.js
+++ b/src/lib/task.js
@@ -339,6 +339,7 @@ class Task extends EventEmitter {
     env.TASKCLUSTER_WORKER_GROUP = this.runtime.workerGroup;
     env.TASKCLUSTER_PUBLIC_IP = this.runtime.publicIp;
     env.TASKCLUSTER_ROOT_URL = this.runtime.rootUrl;
+    env.TASKCLUSTER_WORKER_LOCATION = this.runtime.workerLocation;
 
     let privilegedTask = runAsPrivileged(
       this.task, this.runtime.dockerConfig.allowPrivileged


### PR DESCRIPTION
This variable aims to provide context for which cloud environment the
task is running in.

See
https://github.com/taskcluster/taskcluster-worker-runner/blob/master/README.md
for more details.