### PR TITLE
Bug 1405711: Report worker-shutdown when receiving SIGTERM

### DIFF
--- a/src/lib/shutdown_manager.js
+++ b/src/lib/shutdown_manager.js
@@ -14,6 +14,22 @@ class ShutdownManager extends EventEmitter {
     this.nodeTerminationPoll = config.shutdown.nodeTerminationPoll || 5000;
     this.onIdle = this.onIdle.bind(this);
     this.onWorking = this.onWorking.bind(this);
+    this.exit = false;
+
+    process.on('SIGTERM', () => {
+      this.config.log('Terminating worker due to SIGTERM');
+      this.config.capacity = 0;
+      this.exit = true;
+      this.emit('nodeTermination', true);
+    });
+  }
+
+  // Should we exit the process if we can
+  // The flag is set to true on SIGTERM. We cannot
+  // perform the exit in the signal handler because we
+  // need to cleanup the running tasks first.
+  shouldExit() {
+    return this.exit;
   }
 
   async shutdown() {

--- a/src/lib/task_listener.js
+++ b/src/lib/task_listener.js
@@ -144,7 +144,7 @@ class TaskListener extends EventEmitter {
     let claims = await this.taskQueue.claimWork(availableCapacity);
     let tasksets = await Promise.all(claims.map(this.applySuperseding.bind(this)));
     // call runTaskset for each taskset, but do not wait for it to complete
-    tasksets.forEach(this.runTaskset.bind(this));
+    await Promise.all(tasksets.map(this.runTaskset.bind(this)));
   }
 
   scheduleTaskPoll(nextPoll=this.taskPollInterval) {
@@ -157,6 +157,9 @@ class TaskListener extends EventEmitter {
           err: e,
           stack: e.stack
         });
+      }
+      if (this.runtime.shutdownManager.shouldExit()) {
+        process.exit();
       }
       this.scheduleTaskPoll();
     }, nextPoll);

--- a/test/integration/signal_test.js
+++ b/test/integration/signal_test.js
@@ -1,0 +1,52 @@
+const assert = require('assert');
+const settings = require('../settings');
+const cmd = require('./helper/cmd');
+const DockerWorker = require('../dockerworker');
+const TestWorker = require('../testworker');
+
+suite('Signals test', () => {
+  let worker;
+  setup(() => {
+    settings.cleanup();
+    settings.configure({
+      shutdown: {
+        enabled: true,
+        afterIdleSeconds: 5,
+      }
+    });
+
+    worker = new TestWorker(DockerWorker);
+  });
+
+  teardown(async () => {
+    try {
+      await worker.terminate();
+      settings.cleanup();
+    } catch(e) {
+      settings.cleanup();
+    }
+  });
+
+  test('SIGTERM', async () => {
+    await worker.launch();
+
+    worker.once('task run', async () => {
+      await worker.worker.process.container.kill({signal: 'SIGTERM'});
+    });
+
+    const res = await worker.postToQueue({
+      payload: {
+        features: {
+          localLiveLog: false,
+        },
+        image: 'taskcluster/test-ubuntu',
+        command: cmd(
+          'sleep 30'
+        ),
+        maxRunTime: 60,
+      },
+    });
+    assert.equal(res.status.runs[0].state, 'exception');
+    assert.equal(res.status.runs[0].reasonResolved, 'worker-shutdown');
+  });
+});

--- a/test/integration/vnc_test.js
+++ b/test/integration/vnc_test.js
@@ -114,12 +114,12 @@ suite('interactive vnc', () => {
           if (/^RFB \d\d\d\.\d\d\d\n$/.test(protocolVersion)) {
             accept();
           } else {
-            reject();
+            reject(new Error(`Unexpected protocolVersion ${protocolVersion}`));
           }
         }
       });
       socket.on('error', reject);
-      socket.on('close', reject);
+      socket.on('close', accept);
     });
     socket.close();
   });


### PR DESCRIPTION
When the instance is going to terminate, it sends SIGTERM to all
processes; in this moment we cancel all running tasks with status
"worker-shutdown" and prepare to exit.