### PR TITLE
Bug 1405711: Don't pick a new task after spot termination event r=dustin

### DIFF
--- a/src/lib/task_listener.js
+++ b/src/lib/task_listener.js
@@ -19,7 +19,6 @@ class TaskListener extends EventEmitter {
   constructor(runtime) {
     super();
     this.runtime = runtime;
-    this.capacity = runtime.capacity;
     this.runningTasks = [];
     this.taskQueue = new TaskQueue(this.runtime);
     this.taskPollInterval = this.runtime.taskQueue.pollInterval;
@@ -102,7 +101,7 @@ class TaskListener extends EventEmitter {
       deviceCapacity = 0;
     }
 
-    let runningCapacity = Math.max(this.capacity - this.runningTasks.length, 0);
+    let runningCapacity = Math.max(this.runtime.capacity - this.runningTasks.length, 0);
     let hostCapacity = Math.min(runningCapacity, deviceCapacity);
     this.lastKnownCapacity = hostCapacity;
 
@@ -326,7 +325,7 @@ class TaskListener extends EventEmitter {
     });
 
     let uptime = this.host.billingCycleUptime();
-    let efficiency = (totalRunTime / (this.capacity * (uptime * 1000))) * 100;
+    let efficiency = (totalRunTime / (this.runtime.capacity * (uptime * 1000))) * 100;
     this.runtime.log(
       'reporting efficiency',
       {efficiency, uptime, totalRunTime, capacity: this.capcity});


### PR DESCRIPTION
When we receive a spot termination notice from the worker-runner, the
shutdown manager set the configured capacity to zero and the current
running tasks are killed with `worker-shutdown` state.

`TaskListener` caches the `capacity` configuration, so when the
shutdown manager updates it, `TaskListener` continues reading a stale
value. It then picks another task to run, and when the spot is about
to terminate, the Linux kernel sends a SIGTERM to the running container
and makes the new running task fails.

We fix it by not caching the capacity configuration anymore,
`TaskListener` now reads it directly from the configuration object.