### PR TITLE
Fix container volume test race condition

### DIFF
--- a/test/dockerworker.js
+++ b/test/dockerworker.js
@@ -71,6 +71,10 @@ class DockerWorker {
           'securityfs',
           '/sys/kernel/security',
           '&&',
+          // the umask setting is for we to be able to write inside shared folders
+          'umask',
+          '0000',
+          '&&',
           'node',
           global.asyncDump ? '--require /worker/src/lib/async-dump' : '',
           '/worker/src/bin/worker.js',


### PR DESCRIPTION
To test if the volume cache isn't shared between two concurrent tasks
we start the tasks, and write a different file in each one, and then
check if the files were written each in a different cache entry.

The test intermittently fails because the tasks may not start in
parallel: one may finish before the other starts, and then the worker
will expectedly reuses the cache entry.

To fix this problem, we wait for the two tasks to start by checking
the number of cache entries, and once that happens, we write a flag
file inside each cache to notify the tasks they are good to go.