### PR TITLE
Bug 1405711: Fix race condition between worker-shutdown and task running

### DIFF
--- a/src/lib/shutdown_manager.js
+++ b/src/lib/shutdown_manager.js
@@ -87,6 +87,7 @@ class ShutdownManager extends EventEmitter {
       let terminated = await this.host.getTerminationTime();
 
       if (terminated) {
+        this.exit = true;
         this.config.capacity = 0;
         this.emit('nodeTermination', terminated);
       }

--- a/src/lib/task_listener.js
+++ b/src/lib/task_listener.js
@@ -232,7 +232,8 @@ class TaskListener extends EventEmitter {
     this.runningTasks.push(runningState);
 
     // After going from an idle to a working state issue a 'working' event.
-    if (this.runningTasks.length === 1) {
+    // unless we receive a notification of worker shutdown
+    if (this.runningTasks.length === 1 && !this.runtime.shutdownManager.shouldExit()) {
       this.emit('working', this);
     }
   }
@@ -487,6 +488,10 @@ class TaskListener extends EventEmitter {
       runningState.handler = taskHandler;
 
       this.addRunningTask(runningState);
+
+      if (this.runtime.shutdownManager.shouldExit()) {
+        runningState.handler.abort('worker-shutdown');
+      }
 
       // Run the task and collect runtime metrics.
       await taskHandler.start();

--- a/test/dockerworker.js
+++ b/test/dockerworker.js
@@ -6,6 +6,9 @@ var dockerOpts = require('dockerode-options');
 var DockerProc = require('dockerode-process');
 var dockerUtils = require('dockerode-process/utils');
 var pipe = require('promisepipe');
+var Debug = require('debug');
+
+const debug = Debug('dockerworker');
 
 const IMAGE = 'taskcluster/docker-worker-test:latest';
 
@@ -133,7 +136,11 @@ class DockerWorker {
     if (this.process) {
       var proc = this.process;
       // Ensure the container is killed and removed.
-      await proc.container.kill();
+      try {
+        await proc.container.kill();
+      } catch (e) {
+        debug(e.message);
+      }
       await proc.container.remove();
       this.process = null;
     }


### PR DESCRIPTION
If we receive a 'graceful-shutdown' message from the worker runner but
we have a task that's claimed but not yet in the list of running tasks,
the task is never aborted and finishes with 'failed' status.

We now check if we received a shutdown message after we add the task to
the list of running tasks and abort it if so. This way there is no more
the condition that happened between task claim and task run.