### PR TITLE
Do not shutdown machine for packet.net

### DIFF
--- a/deploy/template/usr/local/bin/load-packet-config
+++ b/deploy/template/usr/local/bin/load-packet-config
@@ -34,6 +34,8 @@ provider:
 workerConfig:
     dockerConfig:
         allowPrivileged: true
+    shutdown:
+        enable: false
 worker:
     implementation: docker-worker
     path: /home/ubuntu/docker_worker


### PR DESCRIPTION
Instances in packet are static provided, so it makes no sense to
shutdown them on idle.