### PR TITLE
Bug 1598211 - don't log an error when an artifact image is not found …

### DIFF
--- a/src/lib/docker/artifact_image.js
+++ b/src/lib/docker/artifact_image.js
@@ -224,8 +224,11 @@ class ArtifactImage {
 
       return true;
     } catch(e) {
-      this.stream.write(fmtLog(`Downloaded image is corrupted: ${e.message}`));
       delete this.knownHashes[`${this.taskId}-${this.artifactPath}`];
+      if (e.statusCode === 404) {
+        return false;
+      }
+      this.stream.write(fmtLog(`Error checking for image presence: ${e.message}`));
       return false;
     }
   }


### PR DESCRIPTION
…locally

I verified that errors from docker.getImage(..).inspect() have a `.statusCode` property, but did not test beyond that.