### PR TITLE
Add a device to mount the host /dev/shm inside the container.

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -17,7 +17,6 @@ tasks:
       - 'docker-worker:capability:privileged'
       - 'docker-worker:capability:device:loopbackAudio'
       - 'docker-worker:capability:device:loopbackVideo'
-      - 'docker-worker:capability:device:hostSharedMemory'
       - 'secrets:get:project/taskcluster/testing/docker-worker/ci-creds'
       - 'secrets:get:project/taskcluster/testing/docker-worker/pulse-creds'
     payload:
@@ -32,7 +31,6 @@ tasks:
         devices:
           loopbackAudio: true
           loopbackVideo: true
-          hostSharedMemory: true
       env:
         WORKER_CI: '1'
         TASKCLUSTER_ROOT_URL: https://community-tc.services.mozilla.com
@@ -61,7 +59,6 @@ tasks:
       - 'docker-worker:capability:privileged'
       - 'docker-worker:capability:device:loopbackAudio'
       - 'docker-worker:capability:device:loopbackVideo'
-      - 'docker-worker:capability:device:hostSharedMemory'
       - 'secrets:get:project/taskcluster/testing/docker-worker/ci-creds'
       - 'secrets:get:project/taskcluster/testing/docker-worker/pulse-creds'
     payload:
@@ -105,7 +102,6 @@ tasks:
       - 'docker-worker:capability:privileged'
       - 'docker-worker:capability:device:loopbackAudio'
       - 'docker-worker:capability:device:loopbackVideo'
-      - 'docker-worker:capability:device:hostSharedMemory'
       - 'secrets:get:project/taskcluster/testing/docker-worker/ci-creds'
       - 'secrets:get:project/taskcluster/testing/docker-worker/pulse-creds'
     payload:
@@ -121,7 +117,6 @@ tasks:
         devices:
           loopbackAudio: true
           loopbackVideo: true
-          hostSharedMemory: true
       env:
         WORKER_CI: '1'
         TASKCLUSTER_ROOT_URL: https://community-tc.services.mozilla.com
@@ -150,7 +145,6 @@ tasks:
       - 'docker-worker:capability:privileged'
       - 'docker-worker:capability:device:loopbackAudio'
       - 'docker-worker:capability:device:loopbackVideo'
-      - 'docker-worker:capability:device:hostSharedMemory'
       - 'secrets:get:project/taskcluster/testing/docker-worker/ci-creds'
       - 'secrets:get:project/taskcluster/testing/docker-worker/pulse-creds'
     payload:
@@ -166,7 +160,6 @@ tasks:
         devices:
           loopbackAudio: true
           loopbackVideo: true
-          hostSharedMemory: true
       env:
         WORKER_CI: '1'
         TASKCLUSTER_ROOT_URL: https://community-tc.services.mozilla.com
@@ -195,7 +188,6 @@ tasks:
       - 'docker-worker:capability:privileged'
       - 'docker-worker:capability:device:loopbackAudio'
       - 'docker-worker:capability:device:loopbackVideo'
-      - 'docker-worker:capability:device:hostSharedMemory'
       - 'secrets:get:project/taskcluster/testing/docker-worker/ci-creds'
       - 'secrets:get:project/taskcluster/testing/docker-worker/pulse-creds'
     payload:
@@ -211,7 +203,6 @@ tasks:
         devices:
           loopbackAudio: true
           loopbackVideo: true
-          hostSharedMemory: true
       env:
         WORKER_CI: '1'
         TASKCLUSTER_ROOT_URL: https://community-tc.services.mozilla.com
@@ -240,7 +231,6 @@ tasks:
       - 'docker-worker:capability:privileged'
       - 'docker-worker:capability:device:loopbackAudio'
       - 'docker-worker:capability:device:loopbackVideo'
-      - 'docker-worker:capability:device:hostSharedMemory'
       - 'secrets:get:project/taskcluster/testing/docker-worker/ci-creds'
       - 'secrets:get:project/taskcluster/testing/docker-worker/pulse-creds'
     payload:
@@ -256,7 +246,6 @@ tasks:
         devices:
           loopbackAudio: true
           loopbackVideo: true
-          hostSharedMemory: true
       env:
         WORKER_CI: '1'
         TASKCLUSTER_ROOT_URL: https://community-tc.services.mozilla.com

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -77,7 +77,6 @@ tasks:
         devices:
           loopbackAudio: true
           loopbackVideo: true
-          hostSharedMemory: true
       env:
         WORKER_CI: '1'
         TASKCLUSTER_ROOT_URL: https://community-tc.services.mozilla.com

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -17,6 +17,7 @@ tasks:
       - 'docker-worker:capability:privileged'
       - 'docker-worker:capability:device:loopbackAudio'
       - 'docker-worker:capability:device:loopbackVideo'
+      - 'docker-worker:capability:device:hostSharedMemory'
       - 'secrets:get:project/taskcluster/testing/docker-worker/ci-creds'
       - 'secrets:get:project/taskcluster/testing/docker-worker/pulse-creds'
     payload:
@@ -31,6 +32,7 @@ tasks:
         devices:
           loopbackAudio: true
           loopbackVideo: true
+          hostSharedMemory: true
       env:
         WORKER_CI: '1'
         TASKCLUSTER_ROOT_URL: https://community-tc.services.mozilla.com
@@ -59,6 +61,7 @@ tasks:
       - 'docker-worker:capability:privileged'
       - 'docker-worker:capability:device:loopbackAudio'
       - 'docker-worker:capability:device:loopbackVideo'
+      - 'docker-worker:capability:device:hostSharedMemory'
       - 'secrets:get:project/taskcluster/testing/docker-worker/ci-creds'
       - 'secrets:get:project/taskcluster/testing/docker-worker/pulse-creds'
     payload:
@@ -74,6 +77,7 @@ tasks:
         devices:
           loopbackAudio: true
           loopbackVideo: true
+          hostSharedMemory: true
       env:
         WORKER_CI: '1'
         TASKCLUSTER_ROOT_URL: https://community-tc.services.mozilla.com
@@ -102,6 +106,7 @@ tasks:
       - 'docker-worker:capability:privileged'
       - 'docker-worker:capability:device:loopbackAudio'
       - 'docker-worker:capability:device:loopbackVideo'
+      - 'docker-worker:capability:device:hostSharedMemory'
       - 'secrets:get:project/taskcluster/testing/docker-worker/ci-creds'
       - 'secrets:get:project/taskcluster/testing/docker-worker/pulse-creds'
     payload:
@@ -117,6 +122,7 @@ tasks:
         devices:
           loopbackAudio: true
           loopbackVideo: true
+          hostSharedMemory: true
       env:
         WORKER_CI: '1'
         TASKCLUSTER_ROOT_URL: https://community-tc.services.mozilla.com
@@ -145,6 +151,7 @@ tasks:
       - 'docker-worker:capability:privileged'
       - 'docker-worker:capability:device:loopbackAudio'
       - 'docker-worker:capability:device:loopbackVideo'
+      - 'docker-worker:capability:device:hostSharedMemory'
       - 'secrets:get:project/taskcluster/testing/docker-worker/ci-creds'
       - 'secrets:get:project/taskcluster/testing/docker-worker/pulse-creds'
     payload:
@@ -160,6 +167,7 @@ tasks:
         devices:
           loopbackAudio: true
           loopbackVideo: true
+          hostSharedMemory: true
       env:
         WORKER_CI: '1'
         TASKCLUSTER_ROOT_URL: https://community-tc.services.mozilla.com
@@ -188,6 +196,7 @@ tasks:
       - 'docker-worker:capability:privileged'
       - 'docker-worker:capability:device:loopbackAudio'
       - 'docker-worker:capability:device:loopbackVideo'
+      - 'docker-worker:capability:device:hostSharedMemory'
       - 'secrets:get:project/taskcluster/testing/docker-worker/ci-creds'
       - 'secrets:get:project/taskcluster/testing/docker-worker/pulse-creds'
     payload:
@@ -203,6 +212,7 @@ tasks:
         devices:
           loopbackAudio: true
           loopbackVideo: true
+          hostSharedMemory: true
       env:
         WORKER_CI: '1'
         TASKCLUSTER_ROOT_URL: https://community-tc.services.mozilla.com
@@ -231,6 +241,7 @@ tasks:
       - 'docker-worker:capability:privileged'
       - 'docker-worker:capability:device:loopbackAudio'
       - 'docker-worker:capability:device:loopbackVideo'
+      - 'docker-worker:capability:device:hostSharedMemory'
       - 'secrets:get:project/taskcluster/testing/docker-worker/ci-creds'
       - 'secrets:get:project/taskcluster/testing/docker-worker/pulse-creds'
     payload:
@@ -246,6 +257,7 @@ tasks:
         devices:
           loopbackAudio: true
           loopbackVideo: true
+          hostSharedMemory: true
       env:
         WORKER_CI: '1'
         TASKCLUSTER_ROOT_URL: https://community-tc.services.mozilla.com

--- a/config.yml
+++ b/config.yml
@@ -7,6 +7,8 @@ defaults:
       enabled: true
     loopbackVideo:
       enabled: true
+    hostSharedMemory:
+      enabled: true
   phone:
     enabled: false
     sims: '1'

--- a/schemas/v1/payload.json
+++ b/schemas/v1/payload.json
@@ -148,7 +148,7 @@
               "type": "boolean"
             },
             "hostSharedMemory": {
-              "title": "Host shared memory device",
+              "title": "Host shared memory device (Experimental)",
               "description": "Mount /dev/shm from the host in the container.",
               "type": "boolean"
             }

--- a/schemas/v1/payload.json
+++ b/schemas/v1/payload.json
@@ -146,6 +146,11 @@
               "title": "Loopback Audio device",
               "description": "Audio loopback device created using snd-aloop",
               "type": "boolean"
+            },
+            "hostSharedMemory": {
+              "title": "Host shared memory device",
+              "description": "Mount /dev/shm from the host in the container.",
+              "type": "boolean"
             }
           }
         }

--- a/src/lib/devices/device_manager.js
+++ b/src/lib/devices/device_manager.js
@@ -44,6 +44,9 @@ class DeviceManager {
 
   async getAvailableCapacity() {
     let devices = await Promise.all(Object.keys(this.managers).map(async (manager) => {
+      if (this.managers[manager].unlimitedDevices) {
+        return Infinity;
+      }
       let availableDevices = await this.managers[manager].getAvailableDevices();
       return availableDevices.length;
     }));

--- a/src/lib/devices/device_manager.js
+++ b/src/lib/devices/device_manager.js
@@ -3,6 +3,7 @@ const Debug = require('debug');
 const VideoDeviceManager = require('./video_device_manager');
 const AudioDeviceManager = require('./audio_device_manager');
 const CpuDeviceManager = require('./cpu_device_manager');
+const SharedMemoryDeviceManager = require('./shared_memory_device_manager');
 
 let debug = Debug('taskcluster-docker-worker:deviceManager');
 
@@ -10,6 +11,7 @@ const DEVICE_MANAGERS = {
   'loopbackVideo': VideoDeviceManager,
   'loopbackAudio': AudioDeviceManager,
   'cpu': CpuDeviceManager,
+  'hostSharedMemory': SharedMemoryDeviceManager
 };
 
 

--- a/src/lib/devices/shared_memory_device_manager.js
+++ b/src/lib/devices/shared_memory_device_manager.js
@@ -1,5 +1,4 @@
 const Debug = require('debug');
-const fs = require('fs');
 
 let debug = Debug('taskcluster-docker-worker:devices:sharedMemoryManager');
 
@@ -27,14 +26,14 @@ class SharedMemoryDeviceManager {
 class SharedMemoryDevice {
   constructor() {
     this.mountPoints = [
-      "/dev/shm"
+      '/dev/shm'
     ];
   }
 
   acquire() {}
 
   release() {
-    debug("Device: /dev/shm released");
+    debug('Device: /dev/shm released');
   }
 
 }

--- a/src/lib/devices/shared_memory_device_manager.js
+++ b/src/lib/devices/shared_memory_device_manager.js
@@ -5,24 +5,12 @@ let debug = Debug('taskcluster-docker-worker:devices:sharedMemoryManager');
 
 class SharedMemoryDeviceManager {
   constructor() {
-    this.devices = this.buildDeviceList();
-  }
-
-  buildDeviceList() {
-    let deviceList = ["/dev/shm"];
-    return deviceList;
+    this.devices = [new SharedMemoryDevice("/dev/shm")];
+    this.unlimitedDevices = true;
   }
 
   getAvailableDevice() {
     let devices = this.getAvailableDevices();
-    if (!devices.length) {
-      throw new Error(`
-        Fatal error... Could not acquire shared memory device: ${JSON.stringify(this.devices)}
-      `);
-    }
-
-    debug('Acquiring available device');
-
     let device = devices[0];
     device.acquire();
 
@@ -32,16 +20,13 @@ class SharedMemoryDeviceManager {
   }
 
   getAvailableDevices() {
-    return this.devices.filter((device) => {
-      return device.active === false;
-    });
+    return this.devices;
   }
 }
 
 class SharedMemoryDevice {
-  constructor(path, active=false) {
+  constructor(path) {
     this.path = path;
-    this.active = active;
 
     if (path !== "/dev/shm") {
       throw new Error('SharedMemoryDevice only operates on /dev/shm');
@@ -52,16 +37,10 @@ class SharedMemoryDevice {
     ];
   }
 
-  acquire() {
-    if (this.active) {
-      throw new Error('Device has already been acquired');
-    }
-    this.active = true;
-  }
+  acquire() {}
 
   release() {
     debug(`Device: ${this.path} released`);
-    this.active = false;
   }
 
 }

--- a/src/lib/devices/shared_memory_device_manager.js
+++ b/src/lib/devices/shared_memory_device_manager.js
@@ -1,0 +1,69 @@
+const Debug = require('debug');
+const fs = require('fs');
+
+let debug = Debug('taskcluster-docker-worker:devices:sharedMemoryManager');
+
+class SharedMemoryDeviceManager {
+  constructor() {
+    this.devices = this.buildDeviceList();
+  }
+
+  buildDeviceList() {
+    let deviceList = ["/dev/shm"];
+    return deviceList;
+  }
+
+  getAvailableDevice() {
+    let devices = this.getAvailableDevices();
+    if (!devices.length) {
+      throw new Error(`
+        Fatal error... Could not acquire shared memory device: ${JSON.stringify(this.devices)}
+      `);
+    }
+
+    debug('Acquiring available device');
+
+    let device = devices[0];
+    device.acquire();
+
+    debug(`Device: ${device.path} acquired`);
+
+    return device;
+  }
+
+  getAvailableDevices() {
+    return this.devices.filter((device) => {
+      return device.active === false;
+    });
+  }
+}
+
+class SharedMemoryDevice {
+  constructor(path, active=false) {
+    this.path = path;
+    this.active = active;
+
+    if (path !== "/dev/shm") {
+      throw new Error('SharedMemoryDevice only operates on /dev/shm');
+    }
+
+    this.mountPoints = [
+      "/dev/shm"
+    ];
+  }
+
+  acquire() {
+    if (this.active) {
+      throw new Error('Device has already been acquired');
+    }
+    this.active = true;
+  }
+
+  release() {
+    debug(`Device: ${this.path} released`);
+    this.active = false;
+  }
+
+}
+
+module.exports = SharedMemoryDeviceManager;

--- a/src/lib/devices/shared_memory_device_manager.js
+++ b/src/lib/devices/shared_memory_device_manager.js
@@ -5,7 +5,7 @@ let debug = Debug('taskcluster-docker-worker:devices:sharedMemoryManager');
 
 class SharedMemoryDeviceManager {
   constructor() {
-    this.devices = [new SharedMemoryDevice("/dev/shm")];
+    this.devices = [new SharedMemoryDevice()];
     this.unlimitedDevices = true;
   }
 
@@ -25,13 +25,7 @@ class SharedMemoryDeviceManager {
 }
 
 class SharedMemoryDevice {
-  constructor(path) {
-    this.path = path;
-
-    if (path !== "/dev/shm") {
-      throw new Error('SharedMemoryDevice only operates on /dev/shm');
-    }
-
+  constructor() {
     this.mountPoints = [
       "/dev/shm"
     ];
@@ -40,7 +34,7 @@ class SharedMemoryDevice {
   acquire() {}
 
   release() {
-    debug(`Device: ${this.path} released`);
+    debug("Device: /dev/shm released");
   }
 
 }

--- a/test/integration/device_link_test.js
+++ b/test/integration/device_link_test.js
@@ -175,7 +175,7 @@ suite('device linking within containers', () => {
     );
   });
 
-  test('/dev/shm is shared with the host', async () => {
+  test.skip('/dev/shm is shared with the host', async () => {
     worker = new TestWorker(DockerWorker);
     await worker.launch();
     let task = {

--- a/test/integration/device_link_test.js
+++ b/test/integration/device_link_test.js
@@ -174,4 +174,34 @@ suite('device linking within containers', () => {
       `Worker should just capacity based on the number of devices that could be found:\n${message}`
     );
   });
+
+  test('/dev/shm is shared with the host', async () => {
+    worker = new TestWorker(DockerWorker);
+    await worker.launch();
+    let task = {
+      scopes: ['docker-worker:capability:device:hostSharedMemory'],
+      payload: {
+        capabilities: {
+          devices: {
+            hostSharedMemory: true
+          }
+        },
+        image: 'ubuntu:14.10',
+        command: cmd(
+          'mount | grep dev/shm',
+          'mount | grep dev/shm | grep -vq size= || { echo \'/dev/shm should not contain size\'; exit 1; }'
+        ),
+        maxRunTime: 5 * 60
+      }
+    };
+
+    let result = await worker.postToQueue(task);
+
+    assert.equal(result.status.state, 'completed', 'Task state is not marked as completed');
+    assert.equal(
+      result.run.reasonResolved,
+      'completed',
+      'Task not resolved as complete'
+    );
+  });
 });


### PR DESCRIPTION
We do this when fuzzing, since Firefox needs a lot of space in /dev/shm and sizing it properly is not straightforward.