### PR TITLE
Fix instanceBoot time

### DIFF
--- a/src/lib/task_listener.js
+++ b/src/lib/task_listener.js
@@ -180,7 +180,7 @@ class TaskListener extends EventEmitter {
 
     this.runtime.logEvent({
       eventType: 'instanceBoot',
-      timestamp: Date.now() - os.uptime(),
+      timestamp: Date.now() - (os.uptime() * 1000),
     });
 
     this.runtime.logEvent({eventType: 'workerReady'});


### PR DESCRIPTION
os.uptime() returns a number of seconds since boot, so we need to multiply this by 1000 to get a proper offset from Date.now().