### PR TITLE
Bug 1520824: add kvm device

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -9,6 +9,8 @@ defaults:
       enabled: true
     hostSharedMemory:
       enabled: true
+    kvm:
+      enabled: true
   phone:
     enabled: false
     sims: '1'

--- a/schemas/v1/payload.json
+++ b/schemas/v1/payload.json
@@ -151,6 +151,11 @@
               "title": "Host shared memory device (Experimental)",
               "description": "Mount /dev/shm from the host in the container.",
               "type": "boolean"
+            },
+            "kvm": {
+              "title": "/dev/kvm device (Experimental)",
+              "description": "Mount /dev/kvm from the host in the container.",
+              "type": "boolean"
             }
           }
         }

--- a/src/lib/devices/device_manager.js
+++ b/src/lib/devices/device_manager.js
@@ -4,6 +4,7 @@ const VideoDeviceManager = require('./video_device_manager');
 const AudioDeviceManager = require('./audio_device_manager');
 const CpuDeviceManager = require('./cpu_device_manager');
 const SharedMemoryDeviceManager = require('./shared_memory_device_manager');
+const KvmDeviceManager = require('./kvm_device_manager');
 
 let debug = Debug('taskcluster-docker-worker:deviceManager');
 
@@ -11,7 +12,8 @@ const DEVICE_MANAGERS = {
   'loopbackVideo': VideoDeviceManager,
   'loopbackAudio': AudioDeviceManager,
   'cpu': CpuDeviceManager,
-  'hostSharedMemory': SharedMemoryDeviceManager
+  'hostSharedMemory': SharedMemoryDeviceManager,
+  'kvm': KvmDeviceManager,
 };
 
 

--- a/src/lib/devices/kvm_device_manager.js
+++ b/src/lib/devices/kvm_device_manager.js
@@ -1,0 +1,41 @@
+const Debug = require('debug');
+
+let debug = Debug('taskcluster-docker-worker:devices:kvmManager');
+
+class KvmDeviceManager {
+  constructor() {
+    this.devices = [new KvmDevice()];
+    this.unlimitedDevices = true;
+  }
+
+  getAvailableDevice() {
+    let devices = this.getAvailableDevices();
+    let device = devices[0];
+    device.acquire();
+
+    debug(`Device: ${device.path} acquired`);
+
+    return device;
+  }
+
+  getAvailableDevices() {
+    return this.devices;
+  }
+}
+
+class KvmDevice {
+  constructor() {
+    this.mountPoints = [
+      '/dev/kvm'
+    ];
+  }
+
+  acquire() {}
+
+  release() {
+    debug('Device: /dev/kvm released');
+  }
+
+}
+
+module.exports = KvmDeviceManager;


### PR DESCRIPTION
When enabled, it exposes /dev/kvm to the container, allowing to run
emulators with hardware virtualization support.