### PR TITLE
Delegate instance shutdown to the host configuration

### DIFF
--- a/src/lib/host/packet.js
+++ b/src/lib/host/packet.js
@@ -112,4 +112,7 @@ module.exports = {
   billingCycleUptime() {
     return os.uptime();
   },
+  async shutdown() {
+    // do nothing
+  },
 };

--- a/src/lib/host/taskcluster-worker-runner.js
+++ b/src/lib/host/taskcluster-worker-runner.js
@@ -15,6 +15,7 @@ module.exports = {
     // docker-worker doesn't support a finish-your-tasks-first termination,
     // so we ignore that portion of the message
     protocol.addCapability('graceful-termination');
+    protocol.addCapability('shutdown');
     protocol.on('graceful-termination-msg', () => {
       gracefulTermination = true;
     });
@@ -39,5 +40,12 @@ module.exports = {
     }
     const content = fs.readFileSync(configFile, 'utf8');
     return JSON.parse(content);
-  }
+  },
+
+  async shutdown() {
+    if (!await protocol.capable('shutdown')) {
+      throw new Error('Shutdown called but worker-runner doesn\'t support this capability');
+    }
+    protocol.send({type: 'shutdown'});
+  },
 };

--- a/src/lib/host/test.js
+++ b/src/lib/host/test.js
@@ -50,5 +50,8 @@ module.exports = {
     } catch (e) {
       return config;
     }
-  }
+  },
+  async shutdown() {
+    process.exit(0);
+  },
 };

--- a/src/lib/shutdown_manager.js
+++ b/src/lib/shutdown_manager.js
@@ -1,5 +1,4 @@
 const { EventEmitter } = require('events');
-const { spawn } = require('child_process');
 
 class ShutdownManager extends EventEmitter {
   constructor(host, config) {
@@ -36,7 +35,8 @@ class ShutdownManager extends EventEmitter {
 
     this.config.log('shutdown');
     this.config.logEvent({eventType: 'instanceShutdown'});
-    spawn('shutdown', ['-h', 'now']);
+    this.config.log('exit');
+    await this.host.shutdown();
   }
 
   onIdle() {


### PR DESCRIPTION
Now each host configuration must implement a "shutdown" function. In the
case of worker-runner, it will call worker-manager removeWorker API and,
if it fails, falls back to a "system shutdown".

This must fix the problem in which instances start to shutdown but
stalls in the middle of the process, hanging forever.

Depends on: https://github.com/taskcluster/taskcluster/pull/2425