### PR TITLE
Wait until the worker-runner protocol has initialized

### DIFF
--- a/src/lib/worker-runner-protocol.js
+++ b/src/lib/worker-runner-protocol.js
@@ -75,7 +75,13 @@ class Protocol extends EventEmitter {
       this.emit(event, msg);
     });
 
-    this.on('welcome-msg', msg => this._handleWelcome(msg));
+    // create a promise that will resolve when we have received a welcome
+    // message and know the extent of capabilities available.
+    this._welcomedPromise = new Promise(resolve =>
+      this.on('welcome-msg', msg => {
+        this._handleWelcome(msg);
+        resolve();
+      }));
   }
 
   /**
@@ -88,7 +94,8 @@ class Protocol extends EventEmitter {
   /**
    * Check whether a particular capability is available
    */
-  capable(cap) {
+  async capable(cap) {
+    await this._welcomedPromise;
     return this.capabilities.has(cap);
   }
 

--- a/test/worker-runner-protocol_test.js
+++ b/test/worker-runner-protocol_test.js
@@ -92,15 +92,16 @@ suite('worker-runner-protocol', function() {
       const transp = new TestTransport();
       const prot = new Protocol(transp, new Set(['worker-only', 'shared']));
 
-      assert.equal(prot.capable('worker-only'), false);
-      assert.equal(prot.capable('shared'), false);
-      assert.equal(prot.capable('runner-only'), false);
+      // `capable` doesn't return yet..
+      let returned = false;
+      prot.capable('worker-only').then(() => { returned = true; });
+      assert.equal(returned, false);
 
       transp.fakeReceive({type: 'welcome', capabilities: ['shared', 'runner-only']});
 
-      assert.equal(prot.capable('worker-only'), false);
-      assert.equal(prot.capable('shared'), true);
-      assert.equal(prot.capable('runner-only'), false);
+      assert.equal(await prot.capable('worker-only'), false);
+      assert.equal(await prot.capable('shared'), true);
+      assert.equal(await prot.capable('runner-only'), false);
     });
 
     test('sending', async function() {


### PR DESCRIPTION
This causes `capable` checks to block until the protocol is established.
It also makes the `capable` method async, but at this point it has no
uses outside of tests.

A downside of this approach is that anything calling `capable` will hang forever if docker-worker is run without worker-runner.  In generic-worker it was important to maintain the ability to run the worker "alone", so we added a `--with-worker-runner` command-line flag which indicates to generic-worker that it's running under worker-runner.  When that flag is missing, generic-worker just assumes all capabilities aren't set.  We could do something similar for docker-worker if that's useful.  What do you think?