### PR TITLE
Remove aws-provisioner builds

### DIFF
--- a/deploy/bin/build
+++ b/deploy/bin/build
@@ -54,7 +54,7 @@ cmd_app() {
           # NOTE: if building a new base AMI, either generate for all of these
           # accounts, or comment out the accounts you have not updated so that
           # the next person is not surprised by using an old base
-          mozilla-taskcluster) hvmSourceAMI=ami-020341c6d42f39567;;
+          mozilla-taskcluster) hvmSourceAMI=ami-0714957760d5b7d84;;
           #taskcluster-aws-staging) hvmSourceAMI=ami-0d04f4da59f322673;;
           *)
               echo "No base AMI defined for AWS account $AWS_ACCOUNT; create one" >&2
@@ -166,7 +166,7 @@ if [ -f packer-artifacts.json ]; then
         | split(":")
       ]
       | flatten
-      | { (.[0]): .[1], (.[2]): .[3], (.[4]): .[5], (.[6]): .[7] }
+      | { (.[0]): .[1], (.[2]): .[3] }
     }
   ' packer-artifacts.json | jq -s add > docker-worker-amis.json
 fi

--- a/deploy/packer/app.json
+++ b/deploy/packer/app.json
@@ -44,13 +44,13 @@
         "./gen-ed25519-key.js",
         "rm -rf node_modules package.json"
       ],
-      "only":           ["hvm-builder", "hvm-builder-wm", "gcp"]
+      "only":           ["hvm-builder", "gcp"]
     },
     {
       "type":           "file",
       "source":         "{{user `cotEd25519SigningKey`}}",
       "destination":    "/tmp/docker-worker-ed25519-cot-signing-key.key",
-      "only":           ["hvm-builder-trusted", "hvm-builder-trusted-wm"]
+      "only":           ["hvm-builder-trusted"]
     },
     {
       "type":           "shell",
@@ -63,16 +63,9 @@
     {
       "type":           "shell",
       "inline": [
-        "/tmp/deploy.sh /tmp/deploy.tar.gz /tmp/docker-worker.tgz aws {{user `deployment`}}"
-      ],
-      "only":           ["hvm-builder-trusted", "hvm-builder"]
-    },
-    {
-      "type":           "shell",
-      "inline": [
         "providerType=aws /tmp/deploy.sh /tmp/deploy.tar.gz /tmp/docker-worker.tgz aws {{user `deployment`}}"
       ],
-      "only":           ["hvm-builder-trusted-wm", "hvm-builder-wm"]
+      "only":           ["hvm-builder-trusted", "hvm-builder"]
     },
     {
       "type":           "shell",
@@ -87,11 +80,11 @@
       "type":           "amazon-ebs",
       "name":           "hvm-builder",
       "region":         "us-west-2",
-      "ami_regions":    ["us-west-1", "us-east-1", "eu-central-1"],
+      "ami_regions":    ["us-west-1", "us-east-1"],
       "source_ami":     "{{user `hvmSourceAMI`}}",
       "instance_type":  "m5.large",
       "ssh_username":   "ubuntu",
-      "ami_name":       "taskcluster-docker-worker{{timestamp}}",
+      "ami_name":       "taskcluster-docker-worker-{{timestamp}}",
       "tags": {
         "OS_Version":       "Ubuntu",
         "Release":          "Latest",
@@ -103,43 +96,11 @@
       "type":           "amazon-ebs",
       "name":           "hvm-builder-trusted",
       "region":         "us-west-2",
-      "ami_regions":    ["us-west-1", "us-east-1", "eu-central-1"],
+      "ami_regions":    ["us-west-1", "us-east-1"],
       "source_ami":     "{{user `hvmSourceAMI`}}",
       "instance_type":  "m5.large",
       "ssh_username":   "ubuntu",
       "ami_name":       "taskcluster-docker-worker-trusted-{{timestamp}}",
-      "tags": {
-        "OS_Version":       "Ubuntu",
-        "Release":          "Latest",
-        "Revision":         "{{user `workerRevision`}}",
-        "Base_AMI":         "{{user `hvmSourceAMI`}}"
-      }
-    },
-    {
-      "type":           "amazon-ebs",
-      "name":           "hvm-builder-wm",
-      "region":         "us-west-2",
-      "ami_regions":    ["us-west-1", "us-east-1", "eu-central-1"],
-      "source_ami":     "{{user `hvmSourceAMI`}}",
-      "instance_type":  "m5.large",
-      "ssh_username":   "ubuntu",
-      "ami_name":       "taskcluster-docker-worker-wm-{{timestamp}}",
-      "tags": {
-        "OS_Version":       "Ubuntu",
-        "Release":          "Latest",
-        "Revision":         "{{user `workerRevision`}}",
-        "Base_AMI":         "{{user `hvmSourceAMI`}}"
-      }
-    },
-    {
-      "type":           "amazon-ebs",
-      "name":           "hvm-builder-trusted-wm",
-      "region":         "us-west-2",
-      "ami_regions":    ["us-west-1", "us-east-1", "eu-central-1"],
-      "source_ami":     "{{user `hvmSourceAMI`}}",
-      "instance_type":  "m5.large",
-      "ssh_username":   "ubuntu",
-      "ami_name":       "taskcluster-docker-worker-trusted-wm-{{timestamp}}",
       "tags": {
         "OS_Version":       "Ubuntu",
         "Release":          "Latest",


### PR DESCRIPTION
aws-provisioner is gone, we don't need to build images for it anymore.

Also, update the base image with new certificate.